### PR TITLE
Fix verified Wiki.js 2.x bug backlog

### DIFF
--- a/client/components/admin.vue
+++ b/client/components/admin.vue
@@ -230,6 +230,11 @@ export default {
       query: statsQuery,
       fetchPolicy: 'network-only',
       manual: true,
+      variables () {
+        return {
+          manageSystem: this.hasPermission('manage:system')
+        }
+      },
       result({ data, loading, networkStatus }) {
         this.info = data.system.info
       },

--- a/client/components/admin/admin-dashboard.vue
+++ b/client/components/admin/admin-dashboard.vue
@@ -40,7 +40,7 @@
               :formatValue='round'
               easing='easeOutQuint'
               )
-      v-flex(xs12 md6 lg12 xl3 d-flex)
+      v-flex(xs12 md6 lg12 xl3 d-flex, v-if='hasPermission(`manage:system`)')
         v-card.dashboard-card.animated.fadeInUp.wait-p6s(
           :class='isLatestVersion ? "green" : "red lighten-2"'
           dark

--- a/client/components/admin/admin-storage.vue
+++ b/client/components/admin/admin-storage.vue
@@ -59,13 +59,13 @@
                     v-icon(color='white') mdi-check-circle
                   v-list-item-content
                     v-list-item-title.body-2 {{tgt.title}}
-                    v-list-item-subtitle.green--text.caption {{$t('admin:storage.lastSync', { time: $options.filters.moment(tgt.lastAttempt, 'from') })}}
+                    v-list-item-subtitle.storage-status-description.green--text.caption {{$t('admin:storage.lastSync', { time: $options.filters.moment(tgt.lastAttempt, 'from') })}}
                 template(v-else)
                   v-list-item-avatar(color='red')
                     v-icon(color='white') mdi-close-circle-outline
                   v-list-item-content
                     v-list-item-title.body-2 {{tgt.title}}
-                    v-list-item-subtitle.red--text.caption {{$t('admin:storage.lastSyncAttempt', { time: $options.filters.moment(tgt.lastAttempt, 'from') })}}
+                    v-list-item-subtitle.storage-status-description.red--text.caption {{$t('admin:storage.lastSyncAttempt', { time: $options.filters.moment(tgt.lastAttempt, 'from') })}}
                   v-list-item-action
                     v-menu
                       template(v-slot:activator='{ on }')
@@ -367,6 +367,12 @@ export default {
     max-width: 100%;
     max-height: 50px;
   }
+}
+
+.storage-status-description {
+  overflow: visible;
+  text-overflow: initial;
+  white-space: normal;
 }
 
 </style>

--- a/client/components/editor/common/katex.js
+++ b/client/components/editor/common/katex.js
@@ -1,5 +1,7 @@
 // Test if potential opening or closing delimieter
 // Assumes that there is a "$" at state.src[pos]
+const ATTRS_SENTINEL = '\u200B'
+
 function isValidDelim (state, pos) {
   let prevChar
   let nextChar
@@ -27,6 +29,10 @@ function isValidDelim (state, pos) {
 }
 
 export default {
+  getContent (content) {
+    return content.endsWith(ATTRS_SENTINEL) ? content.slice(0, -ATTRS_SENTINEL.length) : content
+  },
+
   katexInline (state, silent) {
     let start, match, token, res, pos
 
@@ -81,14 +87,8 @@ export default {
     if (!silent) {
       token = state.push('katex_inline', 'math', 0)
       token.markup = '$'
-      token.content = state.src
-        // Extract the math part without the $
-        .slice(start, match)
-        // Escape the curly braces since they will be interpreted as
-        // attributes by markdown-it-attrs (the "curly_attributes"
-        // core rule)
-        .replaceAll("{", "{{")
-        .replaceAll("}", "}}")
+      // Prevent markdown-it-attrs from treating trailing TeX braces as attributes.
+      token.content = state.src.slice(start, match) + ATTRS_SENTINEL
     }
 
     state.pos = match + 1

--- a/client/components/editor/editor-markdown.vue
+++ b/client/components/editor/editor-markdown.vue
@@ -248,7 +248,7 @@ Prism.plugins.NormalizeWhitespace.setDefaults({
 // Markdown Instance
 const md = new MarkdownIt({
   html: true,
-  breaks: true,
+  breaks: siteConfig.markdownLinebreaks !== false,
   linkify: true,
   typography: true,
   highlight(str, lang) {
@@ -327,13 +327,14 @@ plantuml.init(md, {})
 const macros = {}
 md.inline.ruler.after('escape', 'katex_inline', katexHelper.katexInline)
 md.renderer.rules.katex_inline = (tokens, idx) => {
+  const content = katexHelper.getContent(tokens[idx].content)
   try {
-    return katex.renderToString(tokens[idx].content, {
+    return katex.renderToString(content, {
       displayMode: false, macros
     })
   } catch (err) {
     console.warn(err)
-    return tokens[idx].content
+    return content
   }
 }
 md.block.ruler.after('blockquote', 'katex_block', katexHelper.katexBlock, {

--- a/client/components/editor/editor-modal-media.vue
+++ b/client/components/editor/editor-modal-media.vue
@@ -142,7 +142,7 @@
                 :label-idle='$t(`editor:assets.uploadAssetsDropZone`)'
                 allow-multiple='true'
                 :files='files'
-                max-files='10'
+                :max-files='siteConfig.uploadMaxFiles'
                 :server='filePondServerOpts'
                 :instant-upload='false'
                 :allow-revert='false'
@@ -150,7 +150,7 @@
               )
             v-divider
             v-card-actions.pa-3
-              .caption.grey--text.text-darken-2 Max 10 files, 5 MB each
+              .caption.grey--text.text-darken-2 Max {{siteConfig.uploadMaxFiles}} files, {{siteConfig.uploadMaxFileSize | prettyBytes}} each
               v-spacer
               v-btn.px-4(color='teal', dark, @click='upload') {{$t('common:actions.upload')}}
 
@@ -240,6 +240,8 @@ import createAssetFolderMutation from 'gql/editor/editor-media-mutation-folder-c
 import renameAssetMutation from 'gql/editor/editor-media-mutation-asset-rename.gql'
 import deleteAssetMutation from 'gql/editor/editor-media-mutation-asset-delete.gql'
 
+/* global siteConfig */
+
 const FilePond = vueFilePond()
 const localeSegmentRegex = /^[A-Z]{2}(-[A-Z]{2})?$/i
 const disallowedFolderChars = /[A-Z()=.!@#$%?&*+`~<>,;:\\/[\]¬{| ]/
@@ -282,6 +284,9 @@ export default {
     }
   },
   computed: {
+    siteConfig () {
+      return siteConfig
+    },
     isShown: {
       get() { return this.value },
       set(val) { this.$emit('input', val) }
@@ -371,6 +376,7 @@ export default {
     insert () {
       const asset = _.find(this.assets, ['id', this.currentFileId])
       const assetPath = this.folderTree.map(f => f.slug).join('/')
+      // eslint-disable-next-line vue/custom-event-name-casing
       this.$root.$emit('editorInsert', {
         kind: asset.kind,
         path: this.currentFolderId > 0 ? `/${assetPath}/${asset.filename}` : `/${asset.filename}`,

--- a/client/components/tags.vue
+++ b/client/components/tags.vue
@@ -1,7 +1,16 @@
 <template lang='pug'>
   v-app(:dark='$vuetify.theme.dark').tags
     nav-header
-    v-navigation-drawer.pb-0.elevation-1(app, fixed, clipped, :right='$vuetify.rtl', permanent, width='300')
+    v-navigation-drawer.pb-0.elevation-1(
+      app
+      fixed
+      clipped
+      :right='$vuetify.rtl'
+      v-model='drawerShown'
+      :permanent='$vuetify.breakpoint.mdAndUp'
+      :temporary='$vuetify.breakpoint.smAndDown'
+      width='300'
+    )
       vue-scroll(:ops='scrollStyle')
         v-list(dense, nav)
           v-list-item(href='/')
@@ -16,7 +25,14 @@
                 v-icon(v-else) mdi-checkbox-blank-outline
               v-list-item-title {{tag.title}}
     v-content.grey(:class='$vuetify.theme.dark ? `darken-4-d5` : `lighten-3`')
-      v-toolbar(color='primary', dark, flat, height='58')
+      v-toolbar.tags-selection-toolbar(color='primary', dark, flat, height='auto')
+        v-btn.mr-2(
+          v-if='$vuetify.breakpoint.smAndDown'
+          icon
+          @click='drawerShown = true'
+          :aria-label='$t(`tags:selectOneMoreTags`)'
+        )
+          v-icon mdi-tag-multiple
         template(v-if='selection.length > 0')
           .overline.mr-3.animated.fadeInLeft {{$t('tags:currentSelection')}}
           v-chip.mr-3.primary--text(
@@ -39,7 +55,7 @@
         template(v-else)
           v-icon.mr-3.animated.fadeInRight mdi-arrow-left
           .overline.animated.fadeInRight {{$t('tags:selectOneMoreTags')}}
-      v-toolbar(:color='$vuetify.theme.dark ? `grey darken-4-l5` : `grey lighten-4`', flat, height='58')
+      v-toolbar.tags-filter-toolbar(:color='$vuetify.theme.dark ? `grey darken-4-l5` : `grey lighten-4`', flat, height='auto')
         v-text-field.tags-search(
           v-model='innerSearch'
           :label='$t(`tags:searchWithinResultsPlaceholder`)'
@@ -56,7 +72,7 @@
         template(v-if='locales.length > 1')
           v-divider.mx-3(vertical)
           .overline {{$t('tags:locale')}}
-          v-select.ml-2(
+          v-select.ml-2.tags-filter-select(
             :items='locales'
             v-model='locale'
             :background-color='$vuetify.theme.dark ? `grey darken-3` : `white`'
@@ -72,7 +88,7 @@
           )
         v-divider.mx-3(vertical)
         .overline {{$t('tags:orderBy')}}
-        v-select.ml-2(
+        v-select.ml-2.tags-filter-select(
           :items='orderByItems'
           v-model='orderBy'
           :background-color='$vuetify.theme.dark ? `grey darken-3` : `white`'
@@ -84,7 +100,7 @@
           height='40'
           style='max-width: 250px;'
         )
-        v-btn-toggle.ml-2(v-model='orderByDirection', rounded, mandatory)
+        v-btn-toggle.ml-2.tags-direction(v-model='orderByDirection', rounded, mandatory)
           v-btn(text, height='40'): v-icon(size='20') mdi-chevron-double-up
           v-btn(text, height='40'): v-icon(size='20') mdi-chevron-double-down
       v-divider
@@ -170,6 +186,7 @@ export default {
   data() {
     return {
       tags: [],
+      drawerShown: false,
       selection: [],
       innerSearch: '',
       locale: 'any',
@@ -237,6 +254,9 @@ export default {
     orderByDirection (newValue, oldValue) {
       this.rebuildURL()
       this.pagination.sortDesc = [newValue === 1]
+    },
+    '$vuetify.breakpoint.mdAndUp' (isDesktop) {
+      this.drawerShown = isDesktop
     }
   },
   router,
@@ -245,6 +265,7 @@ export default {
     this.selection = _.compact(decodeURI(this.$route.path).split('/'))
   },
   mounted () {
+    this.drawerShown = this.$vuetify.breakpoint.mdAndUp
     this.locales = _.concat(
       [{name: this.$t('tags:localeAny'), code: 'any'}],
       (siteLangs.length > 0 ? siteLangs : [])
@@ -294,7 +315,7 @@ export default {
       this.$router.push(urlObj)
     },
     goTo (page) {
-      window.location.assign(`/${page.locale}/${page.path}`)
+      window.location.assign(siteLangs.length > 0 ? `/${page.locale}/${page.path}` : `/${page.path}`)
     }
   },
   apollo: {
@@ -330,11 +351,48 @@ export default {
 
 <style lang='scss'>
 .tags-search {
+  flex: 1 1 240px;
+
   .v-input__control {
     min-height: initial !important;
   }
   .v-input__prepend-outer {
     margin-top: 8px !important;
+  }
+}
+
+.tags-selection-toolbar, .tags-filter-toolbar {
+  min-height: 58px;
+
+  .v-toolbar__content {
+    flex-wrap: wrap;
+    gap: 8px;
+    height: auto !important;
+    min-height: 58px;
+    padding-top: 8px;
+    padding-bottom: 8px;
+  }
+}
+
+@media (max-width: 600px) {
+  .tags-filter-toolbar {
+    .tags-search {
+      flex-basis: 100%;
+    }
+
+    .v-divider, .overline {
+      display: none;
+    }
+
+    .tags-filter-select {
+      flex: 1 1 calc(50% - 8px);
+      margin-left: 0 !important;
+      max-width: none !important;
+    }
+
+    .tags-direction {
+      margin-left: 0 !important;
+    }
   }
 }
 </style>

--- a/client/graph/admin/dashboard/dashboard-query-stats.gql
+++ b/client/graph/admin/dashboard/dashboard-query-stats.gql
@@ -1,8 +1,8 @@
-query {
+query($manageSystem: Boolean!) {
   system {
     info {
-      currentVersion
-      latestVersion
+      currentVersion @include(if: $manageSystem)
+      latestVersion @include(if: $manageSystem)
       groupsTotal
       pagesTotal
       usersTotal

--- a/client/libs/prism/prism.css
+++ b/client/libs/prism/prism.css
@@ -10,7 +10,7 @@ code[class*="language-"],
 pre[class*="language-"] {
 	color: white;
 	background: none;
-	text-shadow: none;
+	text-shadow: 0 -.1em .2em black;
 	font-family: Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace;
 	text-align: left;
 	white-space: pre;

--- a/client/libs/prism/prism.css
+++ b/client/libs/prism/prism.css
@@ -10,7 +10,7 @@ code[class*="language-"],
 pre[class*="language-"] {
 	color: white;
 	background: none;
-	text-shadow: 0 -.1em .2em black;
+	text-shadow: none;
 	font-family: Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace;
 	text-align: left;
 	white-space: pre;

--- a/client/modules/localization.js
+++ b/client/modules/localization.js
@@ -12,18 +12,24 @@ import localeQuery from 'gql/common/common-localization-query-translations.gql'
 export default {
   VueI18Next,
   init() {
+    let localStorageOptions = null
+    try {
+      if (window.localStorage) {
+        localStorageOptions = {
+          expirationTime: 1000 * 60 * 60 * 24,
+          store: window.localStorage
+        }
+      }
+    } catch (err) {
+      // Web Storage can be denied by browser privacy settings.
+    }
     i18next
       .use(Backend)
       .init({
         backend: {
-          backends: [
-            LocalStorageBackend,
-            i18nextXHR
-          ],
+          backends: localStorageOptions ? [LocalStorageBackend, i18nextXHR] : [i18nextXHR],
           backendOptions: [
-            {
-              expirationTime: 1000 * 60 * 60 * 24 // 24h
-            },
+            ...(localStorageOptions ? [localStorageOptions] : []),
             {
               loadPath: '{{lng}}/{{ns}}',
               parse: (data) => data,

--- a/client/scss/app.scss
+++ b/client/scss/app.scss
@@ -28,4 +28,11 @@
 @import 'pages/welcome';
 @import 'pages/error';
 
+.v-application {
+  code[class*='language-'],
+  pre[class*='language-'] {
+    text-shadow: none;
+  }
+}
+
 @import 'layout/_rtl';

--- a/client/themes/default/components/nav-sidebar.vue
+++ b/client/themes/default/components/nav-sidebar.vue
@@ -51,7 +51,7 @@
             v-icon(small) mdi-folder-open
           v-list-item-title {{ item.title }}
         v-divider.mt-2
-        v-list-item.mt-2(v-if='currentParent.pageId > 0', :href='`/` + currentParent.locale + `/` + currentParent.path', :key='`directorypage-` + currentParent.id', :input-value='path === currentParent.path')
+        v-list-item.mt-2(v-if='currentParent.pageId > 0', :href='pageTarget(currentParent.locale, currentParent.path)', :key='`directorypage-` + currentParent.id', :input-value='path === currentParent.path')
           v-list-item-avatar(size='24')
             v-icon mdi-text-box
           v-list-item-title {{ currentParent.title }}
@@ -61,7 +61,7 @@
           v-list-item-avatar(size='24')
             v-icon mdi-folder
           v-list-item-title {{ item.title }}
-        v-list-item(v-else, :href='`/` + item.locale + `/` + item.path', :key='`childpage-` + item.id', :input-value='path === item.path')
+        v-list-item(v-else, :href='pageTarget(item.locale, item.path)', :key='`childpage-` + item.id', :input-value='path === item.path')
           v-list-item-avatar(size='24')
             v-icon mdi-text-box
           v-list-item-title {{ item.title }}
@@ -112,7 +112,11 @@ export default {
   methods: {
     switchMode (mode) {
       this.currentMode = mode
-      window.localStorage.setItem('navPref', mode)
+      try {
+        window.localStorage.setItem('navPref', mode)
+      } catch (err) {
+        // Web Storage can be denied by browser privacy settings.
+      }
       if (mode === `browse` && this.loadedCache.length < 1) {
         this.loadFromCurrentPath()
       }
@@ -219,6 +223,9 @@ export default {
     },
     goHome () {
       window.location.assign(siteLangs.length > 0 ? `/${this.locale}/home` : '/')
+    },
+    pageTarget (locale, path) {
+      return siteLangs.length > 0 ? `/${locale}/${path}` : `/${path}`
     }
   },
   mounted () {
@@ -228,7 +235,11 @@ export default {
     } else if (this.navMode === 'STATIC') {
       this.currentMode = 'custom'
     } else {
-      this.currentMode = window.localStorage.getItem('navPref') || 'custom'
+      try {
+        this.currentMode = window.localStorage.getItem('navPref') || 'custom'
+      } catch (err) {
+        this.currentMode = 'custom'
+      }
     }
     if (this.currentMode === 'browse') {
       this.loadFromCurrentPath()

--- a/client/themes/default/scss/app.scss
+++ b/client/themes/default/scss/app.scss
@@ -556,7 +556,7 @@
 
           @at-root .is-rtl & {
             border-left-color: mc('grey', '200');
-            border-right-width: mc('blue', '500');
+            border-right-color: mc('blue', '500');
           }
         }
 
@@ -565,7 +565,12 @@
           display: none;
         }
 
-        > a {
+        > p {
+          margin: 0;
+          padding: 0;
+        }
+
+        > a, > p > a {
           display: block;
           text-decoration: none;
           margin: -1rem;
@@ -580,11 +585,26 @@
             border-left: 1px solid mc('grey', '300');
             margin-left: .5rem;
 
+            @at-root .is-rtl & {
+              padding-right: .5rem;
+              padding-left: 0;
+              border-right: 1px solid mc('grey', '300');
+              border-left: none;
+              margin-right: .5rem;
+              margin-left: 0;
+            }
+
             &.is-block {
               display: block;
               padding-left: 0;
               margin-left: 0;
               border-left: none;
+
+              @at-root .is-rtl & {
+                padding-right: 0;
+                margin-right: 0;
+                border-right: none;
+              }
             }
           }
         }
@@ -614,7 +634,7 @@
 
             @at-root .theme--dark.is-rtl & {
               border-left-color: mc('grey', '900');
-              border-right-width: mc('indigo', '300');
+              border-right-color: mc('indigo', '300');
             }
           }
         }

--- a/server/controllers/common.js
+++ b/server/controllers/common.js
@@ -113,6 +113,8 @@ router.get(['/e', '/e/*'], async (req, res, next) => {
   // -> Set Editor Lang
   _.set(res, 'locals.siteConfig.lang', pageArgs.locale)
   _.set(res, 'locals.siteConfig.rtl', req.i18n.dir() === 'rtl')
+  const markdownRenderer = await WIKI.models.renderers.query().findById('markdownCore').select('config')
+  _.set(res, 'locals.siteConfig.markdownLinebreaks', _.get(markdownRenderer, 'config.linebreaks', true))
 
   // -> Check for reserved path
   if (pageHelper.isReservedPath(pageArgs.path)) {
@@ -486,7 +488,11 @@ router.get('/*', async (req, res, next) => {
           l: n.label,
           c: n.icon,
           y: n.targetType,
-          t: n.target
+          t: pageHelper.resolveNavigationHref({
+            target: n.target,
+            targetType: n.targetType,
+            locale: pageArgs.locale
+          })
         }))
 
         // -> Build theme code injection

--- a/server/controllers/ssl.js
+++ b/server/controllers/ssl.js
@@ -1,7 +1,6 @@
 const express = require('express')
 const router = express.Router()
 const _ = require('lodash')
-const qs = require('querystring')
 
 /* global WIKI */
 
@@ -28,7 +27,9 @@ router.get('/.well-known/acme-challenge/:token', (req, res, next) => {
  */
 router.all('/*', (req, res, next) => {
   if (WIKI.config.server.sslRedir && !req.secure && WIKI.servers.servers.https) {
-    return res.redirect(`https://${req.hostname}${req.originalUrl}`)
+    const httpsPort = Number(WIKI.config.ssl.port)
+    const authority = httpsPort && httpsPort !== 443 ? `${req.hostname}:${httpsPort}` : req.hostname
+    return res.redirect(`https://${authority}${req.originalUrl}`)
   } else {
     next()
   }

--- a/server/core/auth.js
+++ b/server/core/auth.js
@@ -162,7 +162,8 @@ module.exports = {
           res.set('Cache-Control', 'no-store')
         } catch (errc) {
           WIKI.logger.warn(errc)
-          return next()
+          user = null
+          res.clearCookie('jwt', commonHelper.getCookieOpts())
         }
       }
 

--- a/server/core/db.js
+++ b/server/core/db.js
@@ -8,6 +8,7 @@ const Objection = require('objection')
 
 const migrationSource = require('../db/migrator-source')
 const migrateFromBeta = require('../db/beta')
+const sslCaHelper = require('../helpers/ssl-ca')
 
 /* global WIKI */
 
@@ -62,15 +63,10 @@ module.exports = {
 
     // Handle inline SSL CA Certificate mode
     if (!_.isEmpty(process.env.DB_SSL_CA)) {
-      const chunks = []
-      for (let i = 0, charsLength = process.env.DB_SSL_CA.length; i < charsLength; i += 64) {
-        chunks.push(process.env.DB_SSL_CA.substring(i, i + 64))
-      }
-
       dbUseSSL = true
       sslOptions = {
         rejectUnauthorized: true,
-        ca: '-----BEGIN CERTIFICATE-----\n' + chunks.join('\n') + '\n-----END CERTIFICATE-----\n'
+        ca: sslCaHelper.resolve(process.env.DB_SSL_CA, WIKI.ROOTPATH)
       }
     }
 

--- a/server/core/letsencrypt.js
+++ b/server/core/letsencrypt.js
@@ -6,6 +6,7 @@ const CSR = require('@root/csr')
 const PEM = require('@root/pem')
 // eslint-disable-next-line node/no-deprecated-api
 const punycode = require('punycode')
+const sslHelper = require('../helpers/ssl')
 
 /* global WIKI */
 
@@ -13,16 +14,17 @@ module.exports = {
   apiDirectory: WIKI.dev ? 'https://acme-staging-v02.api.letsencrypt.org/directory' : 'https://acme-v02.api.letsencrypt.org/directory',
   acme: null,
   async init () {
+    const certificateExpiration = sslHelper.getCertificateExpiration(_.get(WIKI.config.letsencrypt, 'payload.cert', null)) || _.get(WIKI.config.letsencrypt, 'payload.expires', null)
     if (!_.get(WIKI.config, 'letsencrypt.payload', false)) {
       await this.requestCertificate()
     } else if (WIKI.config.letsencrypt.domain !== WIKI.config.ssl.domain) {
       WIKI.logger.info(`(LETSENCRYPT) Domain has changed. Requesting new certificates...`)
       await this.requestCertificate()
-    } else if (moment(WIKI.config.letsencrypt.payload.expires).isSameOrBefore(moment().add(5, 'days'))) {
+    } else if (moment(certificateExpiration).isSameOrBefore(moment().add(5, 'days'))) {
       WIKI.logger.info(`(LETSENCRYPT) Certificate is about to or has expired, requesting a new one...`)
       await this.requestCertificate()
     } else {
-      WIKI.logger.info(`(LETSENCRYPT) Using existing certificate for ${WIKI.config.ssl.domain}, expires on ${WIKI.config.letsencrypt.payload.expires}: [ OK ]`)
+      WIKI.logger.info(`(LETSENCRYPT) Using existing certificate for ${WIKI.config.ssl.domain}, expires on ${certificateExpiration}: [ OK ]`)
     }
     WIKI.config.ssl.format = 'pem'
     WIKI.config.ssl.inline = true

--- a/server/graph/resolvers/page.js
+++ b/server/graph/resolvers/page.js
@@ -173,8 +173,8 @@ module.exports = {
     async singleByPath(obj, args, context, info) {
       let page = await WIKI.models.pages.getPageFromDb({
         path: args.path,
-        locale: args.locale,
-      });
+        locale: args.locale
+      })
       if (page) {
         if (WIKI.auth.checkAccess(context.req.user, ['manage:pages', 'delete:pages'], {
           path: page.path,
@@ -479,8 +479,13 @@ module.exports = {
       try {
         const tagToDel = await WIKI.models.tags.query().findById(args.id)
         if (tagToDel) {
+          const affectedPages = await tagToDel.$relatedQuery('pages').select('pages.hash')
           await tagToDel.$relatedQuery('pages').unrelate()
           await WIKI.models.tags.query().deleteById(args.id)
+          for (const page of affectedPages) {
+            await WIKI.models.pages.deletePageFromCache(page.hash)
+            WIKI.events.outbound.emit('deletePageFromCache', page.hash)
+          }
         } else {
           throw new Error('This tag does not exist.')
         }

--- a/server/graph/resolvers/system.js
+++ b/server/graph/resolvers/system.js
@@ -9,6 +9,7 @@ const graphHelper = require('../../helpers/graph')
 const request = require('request-promise')
 const crypto = require('crypto')
 const nanoid = require('nanoid/non-secure').customAlphabet('1234567890abcdef', 10)
+const sslHelper = require('../../helpers/ssl')
 
 const getosAsync = require('util').promisify(getos)
 
@@ -391,7 +392,17 @@ module.exports = {
       return WIKI.config.ssl.enabled && WIKI.config.ssl.provider === `letsencrypt` ? WIKI.config.ssl.domain : null
     },
     sslExpirationDate () {
-      return WIKI.config.ssl.enabled && WIKI.config.ssl.provider === `letsencrypt` ? _.get(WIKI.config.letsencrypt, 'payload.expires', null) : null
+      if (!WIKI.config.ssl.enabled) {
+        return null
+      }
+      try {
+        const certificate = WIKI.config.ssl.inline ?
+          WIKI.config.ssl.cert :
+          fs.readFileSync(WIKI.config.ssl.cert)
+        return sslHelper.getCertificateExpiration(certificate)
+      } catch (err) {
+        return null
+      }
     },
     sslProvider () {
       return WIKI.config.ssl.enabled ? WIKI.config.ssl.provider : null

--- a/server/helpers/page.js
+++ b/server/helpers/page.js
@@ -19,6 +19,65 @@ const extToContent = _.invert(contentToExt)
 
 module.exports = {
   /**
+   * Check whether a path segment is an active site locale.
+   */
+  isLocaleSegment (segment) {
+    if (!localeSegmentRegex.test(segment)) {
+      return false
+    }
+    const activeLocales = _.uniq([
+      _.get(WIKI.config, 'lang.code', 'en'),
+      ..._.get(WIKI.config, 'lang.namespaces', [])
+    ]).map(locale => locale.toLowerCase())
+    return activeLocales.includes(segment.toLowerCase())
+  },
+  /**
+   * Build a public page href using the site's locale mode.
+   */
+  getPageHref ({ locale, path: pagePath }) {
+    return WIKI.config.lang.namespacing ? `/${locale}/${pagePath}` : `/${pagePath}`
+  },
+  /**
+   * Normalize a configured navigation target for the page's active locale.
+   */
+  resolveNavigationHref ({ target, targetType, locale }) {
+    if (['external', 'externalblank'].includes(targetType)) {
+      return target
+    }
+    if (targetType === 'home') {
+      return WIKI.config.lang.namespacing ? `/${locale}/home` : '/'
+    }
+    let targetPath = _.trimStart(target || '', '/')
+    const targetParts = targetPath.split('/')
+    if (this.isLocaleSegment(targetParts[0])) {
+      targetParts.shift()
+      targetPath = targetParts.join('/')
+    }
+    return this.getPageHref({ locale, path: targetPath })
+  },
+  /**
+   * Resolve a page link using browser URL semantics.
+   */
+  resolvePageHref (href, { locale, path: pagePath, absolute = false }) {
+    const origin = 'http://wikijs.local'
+    let target = href
+    if (WIKI.config.lang.namespacing) {
+      if (_.startsWith(target, '/')) {
+        const firstSegment = target.split('/')[1]
+        if (!this.isLocaleSegment(firstSegment)) {
+          target = `/${locale}${target}`
+        }
+      } else {
+        const basePath = absolute ? `/${locale}/` : `/${locale}/${pagePath}`
+        target = new URL(target, `${origin}${basePath}`).pathname
+      }
+    } else if (!_.startsWith(target, '/')) {
+      const basePath = absolute ? '/' : `/${pagePath}`
+      target = new URL(target, `${origin}${basePath}`).pathname
+    }
+    return target
+  },
+  /**
    * Parse raw url path and make it safe
    */
   parsePath (rawPath, opts = {}) {
@@ -46,7 +105,7 @@ module.exports = {
     if (pathParts[0].length === 1) {
       pathParts.shift()
     }
-    if (localeSegmentRegex.test(pathParts[0])) {
+    if (this.isLocaleSegment(pathParts[0])) {
       pathObj.locale = pathParts[0]
       pathObj.explicitLocale = true
       pathParts.shift()

--- a/server/helpers/page.js
+++ b/server/helpers/page.js
@@ -41,7 +41,7 @@ module.exports = {
    * Normalize a configured navigation target for the page's active locale.
    */
   resolveNavigationHref ({ target, targetType, locale }) {
-    if (['external', 'externalblank'].includes(targetType)) {
+    if (['external', 'externalblank', 'search'].includes(targetType)) {
       return target
     }
     if (targetType === 'home') {
@@ -69,11 +69,13 @@ module.exports = {
         }
       } else {
         const basePath = absolute ? `/${locale}/` : `/${locale}/${pagePath}`
-        target = new URL(target, `${origin}${basePath}`).pathname
+        const parsedTarget = new URL(target, `${origin}${basePath}`)
+        target = `${parsedTarget.pathname}${parsedTarget.search}${parsedTarget.hash}`
       }
     } else if (!_.startsWith(target, '/')) {
       const basePath = absolute ? '/' : `/${pagePath}`
-      target = new URL(target, `${origin}${basePath}`).pathname
+      const parsedTarget = new URL(target, `${origin}${basePath}`)
+      target = `${parsedTarget.pathname}${parsedTarget.search}${parsedTarget.hash}`
     }
     return target
   },

--- a/server/helpers/ssl-ca.js
+++ b/server/helpers/ssl-ca.js
@@ -1,0 +1,24 @@
+const fs = require('fs')
+const path = require('path')
+
+module.exports = {
+  resolve (value, rootPath) {
+    const ca = value.trim()
+    const filePath = path.isAbsolute(ca) ? ca : path.resolve(rootPath, ca)
+    if (fs.existsSync(filePath)) {
+      return fs.readFileSync(filePath)
+    }
+    if (ca.startsWith('-----BEGIN CERTIFICATE-----')) {
+      return ca
+    }
+    const decoded = Buffer.from(ca, 'base64').toString('utf8')
+    if (decoded.startsWith('-----BEGIN CERTIFICATE-----')) {
+      return decoded
+    }
+    const chunks = []
+    for (let i = 0; i < ca.length; i += 64) {
+      chunks.push(ca.substring(i, i + 64))
+    }
+    return `-----BEGIN CERTIFICATE-----\n${chunks.join('\n')}\n-----END CERTIFICATE-----\n`
+  }
+}

--- a/server/helpers/ssl.js
+++ b/server/helpers/ssl.js
@@ -1,0 +1,14 @@
+const crypto = require('crypto')
+
+module.exports = {
+  getCertificateExpiration (certificate) {
+    if (!certificate) {
+      return null
+    }
+    try {
+      return new Date(new crypto.X509Certificate(certificate).validTo).toISOString()
+    } catch (err) {
+      return null
+    }
+  }
+}

--- a/server/master.js
+++ b/server/master.js
@@ -155,7 +155,9 @@ module.exports = async () => {
       company: WIKI.config.company,
       contentLicense: WIKI.config.contentLicense,
       footerOverride: WIKI.config.footerOverride,
-      logoUrl: WIKI.config.logoUrl
+      logoUrl: WIKI.config.logoUrl,
+      uploadMaxFileSize: WIKI.config.uploads.maxFileSize,
+      uploadMaxFiles: WIKI.config.uploads.maxFiles
     }
     res.locals.langs = await WIKI.models.locales.getNavLocales({ cache: true })
     res.locals.analyticsCode = await WIKI.models.analytics.getCode({ cache: true })

--- a/server/models/pages.js
+++ b/server/models/pages.js
@@ -848,7 +848,7 @@ module.exports = class Page extends Model {
    * @returns {Promise} Promise with no value
    */
   static async reconnectLinks (opts) {
-    const pageHref = `/${opts.locale}/${opts.path}`
+    const pageHref = pageHelper.getPageHref({ locale: opts.locale, path: opts.path })
     let replaceArgs = {
       from: '',
       to: ''
@@ -859,7 +859,7 @@ module.exports = class Page extends Model {
         replaceArgs.to = `<a href="${pageHref}" class="is-internal-link is-valid-page">`
         break
       case 'move':
-        const prevPageHref = `/${opts.sourceLocale}/${opts.sourcePath}`
+        const prevPageHref = pageHelper.getPageHref({ locale: opts.sourceLocale, path: opts.sourcePath })
         replaceArgs.from = `<a href="${prevPageHref}" class="is-internal-link is-valid-page">`
         replaceArgs.to = `<a href="${pageHref}" class="is-internal-link is-valid-page">`
         break

--- a/server/models/userKeys.js
+++ b/server/models/userKeys.js
@@ -44,9 +44,9 @@ module.exports = class UserKey extends Model {
     this.createdAt = DateTime.utc().toISO()
   }
 
-  static async generateToken ({ userId, kind }, context) {
+  static async generateToken ({ userId, kind, trx }, context) {
     const token = await nanoid()
-    await WIKI.models.userKeys.query().insert({
+    await WIKI.models.userKeys.query(trx).insert({
       kind,
       token,
       validUntil: DateTime.utc().plus({ days: 1 }).toISO(),

--- a/server/models/users.js
+++ b/server/models/users.js
@@ -731,6 +731,16 @@ module.exports = class User extends Model {
         usrData.appearance = appearance
       }
       await WIKI.models.users.query().patch(usrData).findById(id)
+      if (_.has(usrData, 'name')) {
+        const affectedPages = await WIKI.models.pages.query()
+          .select('hash')
+          .where('authorId', id)
+          .orWhere('creatorId', id)
+        for (const page of affectedPages) {
+          await WIKI.models.pages.deletePageFromCache(page.hash)
+          WIKI.events.outbound.emit('deletePageFromCache', page.hash)
+        }
+      }
     } else {
       throw new WIKI.Error.UserNotFound()
     }
@@ -814,48 +824,67 @@ module.exports = class User extends Model {
       // Check if email already exists
       const usr = await WIKI.models.users.query().findOne({ email, providerKey: 'local' })
       if (!usr) {
-        // Create the account
-        const newUsr = await WIKI.models.users.query().insert({
-          provider: 'local',
-          email,
-          name,
-          password,
-          locale: 'en',
-          defaultEditor: 'markdown',
-          tfaIsActive: false,
-          isSystem: false,
-          isActive: true,
-          isVerified: false
-        })
-
-        // Assign to group(s)
-        if (_.get(localStrg, 'autoEnrollGroups.v', []).length > 0) {
-          await newUsr.$relatedQuery('groups').relate(localStrg.autoEnrollGroups.v)
-        }
-
-        if (verify) {
-          // Create verification token
-          const verificationToken = await WIKI.models.userKeys.generateToken({
-            kind: 'verify',
-            userId: newUsr.id
+        let trx = await WIKI.models.Objection.transaction.start(WIKI.models.knex)
+        try {
+          // Create the account
+          const newUsr = await WIKI.models.users.query(trx).insert({
+            provider: 'local',
+            email,
+            name,
+            password,
+            locale: 'en',
+            defaultEditor: 'markdown',
+            tfaIsActive: false,
+            isSystem: false,
+            isActive: true,
+            isVerified: false
           })
 
-          // Send verification email
-          await WIKI.mail.send({
-            template: 'accountVerify',
-            to: email,
-            subject: 'Verify your account',
-            data: {
-              preheadertext: 'Verify your account in order to gain access to the wiki.',
-              title: 'Verify your account',
-              content: 'Click the button below in order to verify your account and gain access to the wiki.',
-              buttonLink: `${WIKI.config.host}/verify/${verificationToken}`,
-              buttonText: 'Verify'
-            },
-            text: `You must open the following link in your browser to verify your account and gain access to the wiki: ${WIKI.config.host}/verify/${verificationToken}`
-          })
+          // Assign to group(s)
+          if (_.get(localStrg, 'autoEnrollGroups.v', []).length > 0) {
+            await newUsr.$relatedQuery('groups', trx).relate(localStrg.autoEnrollGroups.v)
+          }
+
+          if (verify) {
+            // Create verification token
+            const verificationToken = await WIKI.models.userKeys.generateToken({
+              kind: 'verify',
+              userId: newUsr.id,
+              trx
+            })
+
+            // Send verification email. Recipient-specific SMTP failures must not
+            // disclose whether an address exists on an allowed domain.
+            try {
+              await WIKI.mail.send({
+                template: 'accountVerify',
+                to: email,
+                subject: 'Verify your account',
+                data: {
+                  preheadertext: 'Verify your account in order to gain access to the wiki.',
+                  title: 'Verify your account',
+                  content: 'Click the button below in order to verify your account and gain access to the wiki.',
+                  buttonLink: `${WIKI.config.host}/verify/${verificationToken}`,
+                  buttonText: 'Verify'
+                },
+                text: `You must open the following link in your browser to verify your account and gain access to the wiki: ${WIKI.config.host}/verify/${verificationToken}`
+              })
+            } catch (mailErr) {
+              WIKI.logger.warn(`Registration verification email could not be delivered: ${mailErr.message}`)
+              await trx.rollback()
+              trx = null
+              return true
+            }
+          }
+          await trx.commit()
+          trx = null
+          return true
+        } catch (err) {
+          if (trx) {
+            await trx.rollback()
+          }
+          throw err
         }
-        return true
       } else {
         throw new WIKI.Error.AuthAccountAlreadyExists()
       }

--- a/server/modules/rendering/html-core/renderer.js
+++ b/server/modules/rendering/html-core/renderer.js
@@ -71,16 +71,11 @@ module.exports = {
 
           // -> Add locale prefix if using namespacing
           if (WIKI.config.lang.namespacing) {
-            // -> Reformat paths
-            if (href.indexOf('/') !== 0) {
-              if (this.config.absoluteLinks) {
-                href = `/${this.page.localeCode}/${href}`
-              } else {
-                href = (this.page.path === 'home') ? `/${this.page.localeCode}/${href}` : `/${this.page.localeCode}/${this.page.path}/${href}`
-              }
-            } else if (href.charAt(3) !== '/') {
-              href = `/${this.page.localeCode}${href}`
-            }
+            href = pageHelper.resolvePageHref(href, {
+              locale: this.page.localeCode,
+              path: this.page.path,
+              absolute: this.config.absoluteLinks
+            })
 
             try {
               const parsedUrl = new URL(`http://x${href}`)
@@ -89,14 +84,11 @@ module.exports = {
               return
             }
           } else {
-            // -> Reformat paths
-            if (href.indexOf('/') !== 0) {
-              if (this.config.absoluteLinks) {
-                href = `/${href}`
-              } else {
-                href = (this.page.path === 'home') ? `/${href}` : `/${this.page.path}/${href}`
-              }
-            }
+            href = pageHelper.resolvePageHref(href, {
+              locale: this.page.localeCode,
+              path: this.page.path,
+              absolute: this.config.absoluteLinks
+            })
 
             try {
               const parsedUrl = new URL(`http://x${href}`)

--- a/server/modules/rendering/markdown-katex/renderer.js
+++ b/server/modules/rendering/markdown-katex/renderer.js
@@ -1,6 +1,8 @@
 const katex = require('katex')
 const chemParse = require('./mhchem')
 
+const ATTRS_SENTINEL = '\u200B'
+
 /* global WIKI */
 
 // ------------------------------------
@@ -28,13 +30,14 @@ module.exports = {
     if (conf.useInline) {
       mdinst.inline.ruler.after('escape', 'katex_inline', katexInline)
       mdinst.renderer.rules.katex_inline = (tokens, idx) => {
+        const content = stripAttrsSentinel(tokens[idx].content)
         try {
-          return katex.renderToString(tokens[idx].content, {
+          return katex.renderToString(content, {
             displayMode: false, macros
           })
         } catch (err) {
           WIKI.logger.warn(err)
-          return tokens[idx].content
+          return content
         }
       }
     }
@@ -138,11 +141,16 @@ function katexInline (state, silent) {
   if (!silent) {
     token = state.push('katex_inline', 'math', 0)
     token.markup = '$'
-    token.content = state.src.slice(start, match)
+    // Prevent markdown-it-attrs from treating trailing TeX braces as attributes.
+    token.content = state.src.slice(start, match) + ATTRS_SENTINEL
   }
 
   state.pos = match + 1
   return true
+}
+
+function stripAttrsSentinel (content) {
+  return content.endsWith(ATTRS_SENTINEL) ? content.slice(0, -ATTRS_SENTINEL.length) : content
 }
 
 function katexBlock (state, start, end, silent) {

--- a/server/modules/rendering/markdown-mathjax/renderer.js
+++ b/server/modules/rendering/markdown-mathjax/renderer.js
@@ -1,5 +1,7 @@
 const mjax = require('mathjax')
 
+const ATTRS_SENTINEL = '\u200B'
+
 /* global WIKI */
 
 // ------------------------------------
@@ -37,14 +39,15 @@ module.exports = {
     if (conf.useInline) {
       mdinst.inline.ruler.after('escape', 'mathjax_inline', mathjaxInline)
       mdinst.renderer.rules.mathjax_inline = (tokens, idx) => {
+        const content = stripAttrsSentinel(tokens[idx].content)
         try {
-          const result = MathJax.tex2svg(tokens[idx].content, {
+          const result = MathJax.tex2svg(content, {
             display: false
           })
           return MathJax.startup.adaptor.innerHTML(result)
         } catch (err) {
           WIKI.logger.warn(err)
-          return tokens[idx].content
+          return content
         }
       }
     }
@@ -149,11 +152,16 @@ function mathjaxInline (state, silent) {
   if (!silent) {
     token = state.push('mathjax_inline', 'math', 0)
     token.markup = '$'
-    token.content = state.src.slice(start, match)
+    // Prevent markdown-it-attrs from treating trailing TeX braces as attributes.
+    token.content = state.src.slice(start, match) + ATTRS_SENTINEL
   }
 
   state.pos = match + 1
   return true
+}
+
+function stripAttrsSentinel (content) {
+  return content.endsWith(ATTRS_SENTINEL) ? content.slice(0, -ATTRS_SENTINEL.length) : content
 }
 
 function mathjaxBlock (state, start, end, silent) {

--- a/server/test/helpers/page.test.js
+++ b/server/test/helpers/page.test.js
@@ -1,4 +1,17 @@
-const { injectPageMetadata } = require('../../helpers/page')
+const pageHelper = require('../../helpers/page')
+const { injectPageMetadata } = pageHelper
+
+beforeEach(() => {
+  global.WIKI = {
+    config: {
+      lang: {
+        code: 'en',
+        namespacing: false,
+        namespaces: ['en', 'fr']
+      }
+    }
+  }
+})
 
 describe('helpers/page/injectPageMetadata', () => {
   const page = {
@@ -58,5 +71,59 @@ TEST CONTENT`
 
     const result = injectPageMetadata(htmlPage)
     expect(result).toEqual(expected)
+  })
+})
+
+describe('helpers/page/parsePath', () => {
+  it('does not mistake an arbitrary two-letter folder for a locale', () => {
+    expect(pageHelper.parsePath('/db/postgres')).toMatchObject({
+      locale: 'en',
+      path: 'db/postgres',
+      explicitLocale: false
+    })
+  })
+
+  it('recognizes configured locale prefixes', () => {
+    expect(pageHelper.parsePath('/fr/guide')).toMatchObject({
+      locale: 'fr',
+      path: 'guide',
+      explicitLocale: true
+    })
+  })
+})
+
+describe('helpers/page/resolvePageHref', () => {
+  it('resolves relative page links as siblings', () => {
+    expect(pageHelper.resolvePageHref('other-doc', {
+      locale: 'en',
+      path: 'guide/current-doc'
+    })).toBe('/guide/other-doc')
+  })
+
+  it('adds the active locale when namespacing is enabled', () => {
+    global.WIKI.config.lang.namespacing = true
+    expect(pageHelper.resolvePageHref('other-doc', {
+      locale: 'fr',
+      path: 'guide/current-doc'
+    })).toBe('/fr/guide/other-doc')
+  })
+})
+
+describe('helpers/page/resolveNavigationHref', () => {
+  it('uses the current locale instead of a locale stored in the navigation item', () => {
+    global.WIKI.config.lang.namespacing = true
+    expect(pageHelper.resolveNavigationHref({
+      target: '/en/guide',
+      targetType: 'page',
+      locale: 'fr'
+    })).toBe('/fr/guide')
+  })
+
+  it('removes locale prefixes when namespacing is disabled', () => {
+    expect(pageHelper.resolveNavigationHref({
+      target: '/en/guide',
+      targetType: 'page',
+      locale: 'en'
+    })).toBe('/guide')
   })
 })

--- a/server/test/helpers/page.test.js
+++ b/server/test/helpers/page.test.js
@@ -100,6 +100,13 @@ describe('helpers/page/resolvePageHref', () => {
     })).toBe('/guide/other-doc')
   })
 
+  it('preserves query strings and fragments on relative page links', () => {
+    expect(pageHelper.resolvePageHref('other-doc?view=compact#section', {
+      locale: 'en',
+      path: 'guide/current-doc'
+    })).toBe('/guide/other-doc?view=compact#section')
+  })
+
   it('adds the active locale when namespacing is enabled', () => {
     global.WIKI.config.lang.namespacing = true
     expect(pageHelper.resolvePageHref('other-doc', {
@@ -125,5 +132,13 @@ describe('helpers/page/resolveNavigationHref', () => {
       targetType: 'page',
       locale: 'en'
     })).toBe('/guide')
+  })
+
+  it('leaves legacy search targets unchanged', () => {
+    expect(pageHelper.resolveNavigationHref({
+      target: 'release notes',
+      targetType: 'search',
+      locale: 'en'
+    })).toBe('release notes')
   })
 })

--- a/server/test/helpers/ssl-ca.test.js
+++ b/server/test/helpers/ssl-ca.test.js
@@ -1,0 +1,14 @@
+const fs = require('fs')
+const path = require('path')
+const sslCa = require('../../helpers/ssl-ca')
+
+describe('helpers/ssl-ca', () => {
+  it('loads a certificate from a file path', () => {
+    const certificatePath = path.join(__dirname, '../../../node_modules/public-encrypt/test/test_cert.pem')
+    expect(sslCa.resolve(certificatePath, process.cwd())).toEqual(fs.readFileSync(certificatePath))
+  })
+
+  it('keeps headerless certificate data compatible with the existing env format', () => {
+    expect(sslCa.resolve('YWJj', process.cwd())).toBe('-----BEGIN CERTIFICATE-----\nYWJj\n-----END CERTIFICATE-----\n')
+  })
+})

--- a/server/test/helpers/ssl.test.js
+++ b/server/test/helpers/ssl.test.js
@@ -1,0 +1,14 @@
+const fs = require('fs')
+const path = require('path')
+const sslHelper = require('../../helpers/ssl')
+
+describe('helpers/ssl', () => {
+  it('reads the expiration date from the certificate itself', () => {
+    const certificate = fs.readFileSync(path.join(__dirname, '../../../node_modules/public-encrypt/test/test_cert.pem'))
+    expect(sslHelper.getCertificateExpiration(certificate)).toMatch(/^\d{4}-\d{2}-\d{2}T/)
+  })
+
+  it('returns null for invalid certificate data', () => {
+    expect(sslHelper.getCertificateExpiration('invalid')).toBeNull()
+  })
+})

--- a/server/test/modules/rendering/markdown-katex.test.js
+++ b/server/test/modules/rendering/markdown-katex.test.js
@@ -1,0 +1,25 @@
+const MarkdownIt = require('markdown-it')
+const markdownAttrs = require('markdown-it-attrs')
+
+const katexRenderer = require('../../../modules/rendering/markdown-katex/renderer')
+
+beforeEach(() => {
+  global.WIKI = {
+    logger: {
+      warn: jest.fn()
+    }
+  }
+})
+
+describe('rendering/markdown-katex', () => {
+  it('preserves inline TeX expressions ending in braces', () => {
+    const md = new MarkdownIt()
+    katexRenderer.init(md, { useInline: true, useBlocks: false })
+    md.use(markdownAttrs)
+
+    const html = md.render('$\\frac{1}{2}$')
+
+    expect(html).toContain('<mfrac>')
+    expect(html).toContain('\\frac{1}{2}')
+  })
+})


### PR DESCRIPTION
## Summary

Fixes the 21 open Wiki.js 2.x bugs that were verified against `main`. Feature requests, missing validation enhancements, partially implemented features, and issues already fixed on `main` are intentionally excluded.

### Deployment, SSL, and storage

- [requarks/wiki#7942](https://github.com/requarks/wiki/issues/7942): accept a file path, PEM, base64 PEM, or legacy headerless value in `DB_SSL_CA`.
- [requarks/wiki#2945](https://github.com/requarks/wiki/issues/2945): derive SSL expiry from the certificate actually configured and served.
- [requarks/wiki#2364](https://github.com/requarks/wiki/issues/2364): allow storage status text to wrap instead of clipping it.
- [requarks/wiki#1537](https://github.com/requarks/wiki/issues/1537): preserve the configured nonstandard HTTPS port in redirects.
- [requarks/wiki#1182](https://github.com/requarks/wiki/issues/1182): show the configured upload count and size in the media uploader and apply the configured file-count limit in FilePond.

### Authentication, users, and permissions

- [requarks/wiki#1728](https://github.com/requarks/wiki/issues/1728): clear an unrefreshable JWT and continue as the guest user.
- [requarks/wiki#1681](https://github.com/requarks/wiki/issues/1681): skip protected version fields for administrators without `manage:system`.
- [requarks/wiki#1538](https://github.com/requarks/wiki/issues/1538): fall back cleanly when Web Storage is denied.
- [requarks/wiki#1488](https://github.com/requarks/wiki/issues/1488): hide recipient-specific mail errors and roll back undeliverable self-registration accounts.
- [requarks/wiki#982](https://github.com/requarks/wiki/issues/982): invalidate affected page caches after a display-name change.

### Content, rendering, and navigation

- [requarks/wiki#1820](https://github.com/requarks/wiki/issues/1820): use the configured Markdown line-break behavior in editor preview.
- [requarks/wiki#1639](https://github.com/requarks/wiki/issues/1639): correct RTL link-list borders and separators.
- [requarks/wiki#1614](https://github.com/requarks/wiki/issues/1614): reconnect missing-page links using the active locale mode.
- [requarks/wiki#1473](https://github.com/requarks/wiki/issues/1473): invalidate affected pages after deleting a tag.
- [requarks/wiki#1462](https://github.com/requarks/wiki/issues/1462): preserve standalone inline TeX expressions ending in braces.
- [requarks/wiki#1411](https://github.com/requarks/wiki/issues/1411): remove the Prism text shadow that blurs nested code blocks.
- [requarks/wiki#1389](https://github.com/requarks/wiki/issues/1389): style link-list anchors wrapped in Markdown paragraphs.
- [requarks/wiki#1292](https://github.com/requarks/wiki/issues/1292): recognize only configured locale prefixes, preserving two-letter folders.
- [requarks/wiki#1201](https://github.com/requarks/wiki/issues/1201): resolve relative Markdown links as sibling URLs while preserving query strings and fragments.
- [requarks/wiki#1037](https://github.com/requarks/wiki/issues/1037): make Browse by Tags responsive on mobile.
- [requarks/wiki#958](https://github.com/requarks/wiki/issues/958): normalize static and browse-navigation links for the active locale mode.

## Verification

- `npm run build` — passed.
- Targeted ESLint for all changed JavaScript and Vue files — passed.
- Targeted Jest regression suite — 16 tests passed across page URL handling, SSL CA parsing, certificate expiry, and KaTeX brace preservation.
- `git diff --check` — passed.

Manual browser checks against the production build cover all five CSS-only fixes:

- #1037: the tag browser was checked at desktop and iPhone 12 Pro widths; the mobile filter button opens the temporary drawer and the toolbar no longer clips horizontally.
- #1389: paragraph-wrapped consecutive links receive the intended block and negative-margin styles.
- #1639: RTL emphasis separators use the right border and right padding, with the left-side values cleared.
- #1411: Prism code and preformatted blocks compute to `text-shadow: none` with the generated application stylesheet loaded.
- #2364: a constrained storage-status description computes to normal whitespace and visible overflow and wraps across multiple lines.

## Compatibility note

#1201 intentionally changes a relative destination such as `other-doc` on `/guide/current-doc` from the previous child result (`/guide/current-doc/other-doc`) to browser-standard sibling resolution (`/guide/other-doc`). Existing content that relies on the child behavior should use an explicit absolute destination. Legacy `search` navigation targets are left unchanged instead of being treated as page paths; that navigation type is currently disabled in the admin UI.

The repository-wide `npm test -- --runInBand` is not currently green: lint stops on 114 findings in files outside this change. Running raw Jest also discovers `dev/cypress/integration/setup.spec.js`, which fails outside Cypress because `cy` is not defined. These baseline failures are not changed by this PR.
