### PR TITLE
Add small Wiki.js 2.x admin and asset safeguards

### DIFF
--- a/client/components/admin/admin-auth.vue
+++ b/client/components/admin/admin-auth.vue
@@ -140,6 +140,7 @@
                   v-text-field.mb-3(
                     v-else
                     outlined
+                    :type='cfg.value.sensitive ? `password` : `text`'
                     :key='cfg.key'
                     :label='cfg.value.title'
                     v-model='cfg.value.value'

--- a/client/components/admin/admin-navigation.vue
+++ b/client/components/admin/admin-navigation.vue
@@ -145,7 +145,9 @@
                             :label='$t("navigation.label")'
                             prepend-icon='mdi-format-title'
                             v-model='current.label'
+                            :rules='labelRules'
                             counter='255'
+                            maxlength='255'
                           )
                           v-text-field(
                             outlined
@@ -177,7 +179,9 @@
                             :label='$t("navigation.target")'
                             prepend-icon='mdi-near-me'
                             v-model='current.target'
-                            hide-details
+                            :rules='targetRules'
+                            counter='2048'
+                            maxlength='2048'
                           )
                           .d-flex.align-center.mt-4(v-else-if='current.targetType === "page"')
                             v-btn.ml-8(
@@ -194,6 +198,9 @@
                             :label='$t("navigation.navType.searchQuery")'
                             prepend-icon='search'
                             v-model='current.target'
+                            :rules='targetRules'
+                            counter='2048'
+                            maxlength='2048'
                           )
                         v-divider
 
@@ -210,6 +217,9 @@
                             :label='$t("navigation.label")'
                             prepend-icon='mdi-format-title'
                             v-model='current.label'
+                            :rules='labelRules'
+                            counter='255'
+                            maxlength='255'
                           )
                         v-divider
 
@@ -283,6 +293,9 @@ import draggable from 'vuedraggable'
 
 /* global siteConfig, siteLangs */
 
+const labelMaxLength = 255
+const targetMaxLength = 2048
+
 export default {
   components: {
     draggable
@@ -303,6 +316,18 @@ export default {
     }
   },
   computed: {
+    labelRules () {
+      return [
+        value => Boolean(value && value.trim()) || 'A navigation label is required.',
+        value => !value || value.length <= labelMaxLength || `Navigation labels cannot exceed ${labelMaxLength} characters.`
+      ]
+    },
+    targetRules () {
+      return [
+        value => Boolean(value && value.trim()) || 'A navigation target is required.',
+        value => !value || value.length <= targetMaxLength || `Navigation targets cannot exceed ${targetMaxLength} characters.`
+      ]
+    },
     navTypes () {
       return [
         { text: this.$t('navigation.navType.external'), value: 'external' },
@@ -385,7 +410,38 @@ export default {
       this.copyFromLocaleDialogIsShown = false
       this.currentTree = [...this.currentTree, ..._.get(_.find(this.trees, ['locale', this.copyFromLocaleCode]), 'items', null) || []]
     },
+    validateTrees () {
+      for (const tree of this.trees) {
+        for (const item of tree.items) {
+          if (['header', 'link'].includes(item.kind)) {
+            if (!_.isString(item.label) || item.label.trim().length < 1) {
+              throw new Error('Navigation link and header labels cannot be blank.')
+            }
+            if (item.label.length > labelMaxLength) {
+              throw new Error(`Navigation labels cannot exceed ${labelMaxLength} characters.`)
+            }
+          }
+          if (item.kind === 'link') {
+            if (!_.isString(item.targetType) || item.targetType.length < 1) {
+              throw new Error('Navigation links must define a target type.')
+            }
+            if (item.targetType !== 'home' && (!_.isString(item.target) || item.target.trim().length < 1)) {
+              throw new Error('Navigation link targets cannot be blank.')
+            }
+            if (_.isString(item.target) && item.target.length > targetMaxLength) {
+              throw new Error(`Navigation link targets cannot exceed ${targetMaxLength} characters.`)
+            }
+          }
+        }
+      }
+    },
     async save() {
+      try {
+        this.validateTrees()
+      } catch (err) {
+        this.$store.commit('pushGraphError', err)
+        return
+      }
       this.$store.commit(`loadingStart`, 'admin-navigation-save')
       try {
         const resp = await this.$apollo.mutate({

--- a/server/controllers/upload.js
+++ b/server/controllers/upload.js
@@ -3,7 +3,7 @@ const router = express.Router()
 const _ = require('lodash')
 const multer = require('multer')
 const path = require('path')
-const sanitize = require('sanitize-filename')
+const assetHelper = require('../helpers/asset')
 
 /* global WIKI */
 
@@ -76,7 +76,7 @@ router.post('/u', (req, res, next) => {
   }
 
   // Sanitize filename
-  fileMeta.originalname = sanitize(fileMeta.originalname.toLowerCase().replace(/[\s,;#]+/g, '_'))
+  fileMeta.originalname = assetHelper.sanitizeFilename(fileMeta.originalname)
 
   // Check if user can upload at path
   const assetPath = (folderId) ? hierarchy.map(h => h.slug).join('/') + `/${fileMeta.originalname}` : fileMeta.originalname

--- a/server/graph/resolvers/asset.js
+++ b/server/graph/resolvers/asset.js
@@ -76,7 +76,7 @@ module.exports = {
      */
     async renameAsset(obj, args, context) {
       try {
-        const filename = sanitize(args.filename).toLowerCase()
+        const filename = assetHelper.sanitizeFilename(args.filename)
 
         const asset = await WIKI.models.assets.query().findById(args.id)
         if (asset) {

--- a/server/graph/resolvers/navigation.js
+++ b/server/graph/resolvers/navigation.js
@@ -1,4 +1,5 @@
 const graphHelper = require('../../helpers/graph')
+const navigationHelper = require('../../helpers/navigation')
 
 /* global WIKI */
 
@@ -20,6 +21,7 @@ module.exports = {
   NavigationMutation: {
     async updateTree (obj, args, context) {
       try {
+        navigationHelper.validateTree(args.tree)
         await WIKI.models.navigation.query().patch({
           config: args.tree
         }).where('key', 'site')

--- a/server/helpers/asset.js
+++ b/server/helpers/asset.js
@@ -1,5 +1,6 @@
 const crypto = require('crypto')
 const path = require('path')
+const sanitize = require('sanitize-filename')
 
 module.exports = {
   /**
@@ -11,5 +12,12 @@ module.exports = {
 
   getPathInfo(assetPath) {
     return path.parse(assetPath.toLowerCase())
+  },
+
+  /**
+   * Normalize an asset filename for filesystem and Markdown link safety.
+   */
+  sanitizeFilename(filename) {
+    return sanitize(filename.toLowerCase().replace(/[\s,;#()[\]]+/g, '_'))
   }
 }

--- a/server/helpers/navigation.js
+++ b/server/helpers/navigation.js
@@ -1,0 +1,40 @@
+const _ = require('lodash')
+
+const LABEL_MAX_LENGTH = 255
+const TARGET_MAX_LENGTH = 2048
+
+module.exports = {
+  LABEL_MAX_LENGTH,
+  TARGET_MAX_LENGTH,
+
+  /**
+   * Validate navigation values before storing them in the site configuration.
+   */
+  validateTree(trees) {
+    for (const tree of trees) {
+      for (const item of tree.items) {
+        if (['header', 'link'].includes(item.kind)) {
+          if (!_.isString(item.label) || item.label.trim().length < 1) {
+            throw new Error('Navigation link and header labels cannot be blank.')
+          }
+          if (item.label.length > LABEL_MAX_LENGTH) {
+            throw new Error(`Navigation labels cannot exceed ${LABEL_MAX_LENGTH} characters.`)
+          }
+        }
+
+        if (item.kind === 'link') {
+          if (!_.isString(item.targetType) || item.targetType.length < 1) {
+            throw new Error('Navigation links must define a target type.')
+          }
+          if (item.targetType !== 'home' && (!_.isString(item.target) || item.target.trim().length < 1)) {
+            throw new Error('Navigation link targets cannot be blank.')
+          }
+          if (_.isString(item.target) && item.target.length > TARGET_MAX_LENGTH) {
+            throw new Error(`Navigation link targets cannot exceed ${TARGET_MAX_LENGTH} characters.`)
+          }
+        }
+      }
+    }
+    return true
+  }
+}

--- a/server/modules/authentication/ldap/definition.yml
+++ b/server/modules/authentication/ldap/definition.yml
@@ -25,6 +25,7 @@ props:
   bindCredentials:
     title: Admin Bind Credentials
     type: String
+    sensitive: true
     hint: The password of the account used above for binding.
     maxWidth: 600
     order: 3

--- a/server/test/helpers/asset.test.js
+++ b/server/test/helpers/asset.test.js
@@ -1,0 +1,15 @@
+const assetHelper = require('../../helpers/asset')
+
+describe('helpers/asset/sanitizeFilename', () => {
+  it('replaces characters that conflict with Markdown link syntax', () => {
+    expect(assetHelper.sanitizeFilename('a[b).PNG')).toBe('a_b_.png')
+  })
+
+  it('preserves the existing whitespace normalization behavior', () => {
+    expect(assetHelper.sanitizeFilename('My File.PNG')).toBe('my_file.png')
+  })
+
+  it('continues to remove filesystem-unsafe characters', () => {
+    expect(assetHelper.sanitizeFilename('folder/file?.png')).toBe('folderfile.png')
+  })
+})

--- a/server/test/helpers/navigation.test.js
+++ b/server/test/helpers/navigation.test.js
@@ -1,0 +1,54 @@
+const navigationHelper = require('../../helpers/navigation')
+
+const treeWith = item => [{
+  locale: 'en',
+  items: [item]
+}]
+
+describe('helpers/navigation/validateTree', () => {
+  it('accepts valid links, headers, and dividers', () => {
+    expect(navigationHelper.validateTree([{
+      locale: 'en',
+      items: [
+        { kind: 'link', label: 'Home', targetType: 'home', target: '' },
+        { kind: 'link', label: 'Docs', targetType: 'page', target: '/en/docs' },
+        { kind: 'header', label: 'Resources' },
+        { kind: 'divider' }
+      ]
+    }])).toBe(true)
+  })
+
+  it.each(['link', 'header'])('rejects blank %s labels', kind => {
+    expect(() => navigationHelper.validateTree(treeWith({
+      kind,
+      label: '   ',
+      targetType: 'home',
+      target: ''
+    }))).toThrow('Navigation link and header labels cannot be blank.')
+  })
+
+  it('rejects overlong labels', () => {
+    expect(() => navigationHelper.validateTree(treeWith({
+      kind: 'header',
+      label: 'a'.repeat(navigationHelper.LABEL_MAX_LENGTH + 1)
+    }))).toThrow('Navigation labels cannot exceed 255 characters.')
+  })
+
+  it('rejects blank non-home link targets', () => {
+    expect(() => navigationHelper.validateTree(treeWith({
+      kind: 'link',
+      label: 'Documentation',
+      targetType: 'external',
+      target: '   '
+    }))).toThrow('Navigation link targets cannot be blank.')
+  })
+
+  it('rejects overlong link targets', () => {
+    expect(() => navigationHelper.validateTree(treeWith({
+      kind: 'link',
+      label: 'Documentation',
+      targetType: 'external',
+      target: `https://example.com/${'a'.repeat(navigationHelper.TARGET_MAX_LENGTH)}`
+    }))).toThrow('Navigation link targets cannot exceed 2048 characters.')
+  })
+})


### PR DESCRIPTION
## Summary

Implements three small Wiki.js 2.x feature and validation requests that were verified as missing on current `main`:

- [requarks/wiki#1525](https://github.com/requarks/wiki/issues/1525): mark LDAP bind credentials as sensitive and render sensitive authentication settings as password inputs.
- [requarks/wiki#1304](https://github.com/requarks/wiki/issues/1304): normalize Markdown-significant brackets and parentheses in asset filenames on both upload and rename.
- [requarks/wiki#1010](https://github.com/requarks/wiki/issues/1010): reject blank navigation link/header labels and blank non-home link targets, with 255-character label and 2048-character target limits.

## Implementation notes

- Asset filename normalization is centralized in `server/helpers/asset.js`, so uploads and later renames follow the same rules.
- Navigation validation runs in both the admin UI and the GraphQL resolver. Direct API calls therefore cannot persist values that the UI rejects.
- Home navigation items remain valid without a stored target because their destination is implied by `targetType: home`.
- The authentication setting uses reusable `sensitive` metadata rather than hard-coding the LDAP property name in the Vue component.

## Verification

- `npm run build` — passed.
- Targeted ESLint for all changed JavaScript and Vue files — passed.
- Targeted Jest suites — 9 tests passed across asset filename normalization and navigation validation.
- `git diff --check` — passed.

The repository-wide test command retains the pre-existing failures documented in the preceding V2 backlog work; this PR adds focused regression coverage for its new server-side behavior.
