### PR TITLE
Merge remaining V2 follow-ups into main

### DIFF
--- a/client/themes/default/scss/app.scss
+++ b/client/themes/default/scss/app.scss
@@ -1084,6 +1084,39 @@
   }
 
   // ---------------------------------
+  // EMBEDDED MEDIA
+  // ---------------------------------
+
+  figure.media {
+    margin: 1rem 0;
+  }
+
+  .media-embed {
+    position: relative;
+    width: 100%;
+    height: 0;
+    padding-bottom: 56.25%;
+    overflow: hidden;
+
+    iframe {
+      position: absolute;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+      border: 0;
+    }
+
+    &.is-spotify {
+      width: 100%;
+      max-width: 300px;
+      height: 380px;
+      padding-bottom: 0;
+      margin: 0 auto;
+    }
+  }
+
+  // ---------------------------------
   // DETAILS
   // ---------------------------------
 

--- a/server/core/auth.js
+++ b/server/core/auth.js
@@ -163,7 +163,7 @@ module.exports = {
         } catch (errc) {
           WIKI.logger.warn(errc)
           user = null
-          res.clearCookie('jwt', commonHelper.getCookieOpts())
+          res.clearCookie('jwt', commonHelper.getCookieOpts({ persistent: false }))
         }
       }
 

--- a/server/helpers/common.js
+++ b/server/helpers/common.js
@@ -42,9 +42,9 @@ module.exports = {
       return result
     }, {})
   },
-  getCookieOpts () {
+  getCookieOpts ({ persistent = true } = {}) {
     return {
-      expires: DateTime.utc().plus({ days: 365 }).toJSDate(),
+      ...(persistent ? { expires: DateTime.utc().plus({ days: 365 }).toJSDate() } : {}),
       ...(WIKI.config.host.startsWith('https://') ? { secure: true } : {})
     }
   }

--- a/server/helpers/media.js
+++ b/server/helpers/media.js
@@ -1,0 +1,147 @@
+const PROVIDERS = [
+  {
+    key: 'youtube',
+    title: 'YouTube video',
+    match (url) {
+      const host = normalizeHost(url.hostname)
+      if (host === 'youtu.be') {
+        return validMediaId(firstPathSegment(url))
+      }
+      if (!['youtube.com', 'm.youtube.com'].includes(host)) {
+        return null
+      }
+      if (url.pathname === '/watch') {
+        return validMediaId(url.searchParams.get('v'))
+      }
+      const match = url.pathname.match(/^\/(?:embed|v)\/([\w-]+)/)
+      return match ? match[1] : null
+    },
+    buildSrc: id => `https://www.youtube.com/embed/${id}`,
+    allow: 'accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture; web-share'
+  },
+  {
+    key: 'vimeo',
+    title: 'Vimeo video',
+    match (url) {
+      const host = normalizeHost(url.hostname)
+      if (host === 'player.vimeo.com') {
+        const match = url.pathname.match(/^\/video\/(\d+)/)
+        return match ? match[1] : null
+      }
+      if (host !== 'vimeo.com') {
+        return null
+      }
+      const segments = url.pathname.split('/').filter(Boolean)
+      return [...segments].reverse().find(segment => /^\d+$/.test(segment)) || null
+    },
+    buildSrc: id => `https://player.vimeo.com/video/${id}`,
+    allow: 'autoplay; fullscreen; picture-in-picture'
+  },
+  {
+    key: 'dailymotion',
+    title: 'Dailymotion video',
+    match (url) {
+      const host = normalizeHost(url.hostname)
+      if (host === 'dai.ly') {
+        return validMediaId(firstPathSegment(url))
+      }
+      if (host !== 'dailymotion.com') {
+        return null
+      }
+      const match = url.pathname.match(/^\/video\/([\w-]+)/)
+      return match ? match[1] : null
+    },
+    buildSrc: id => `https://www.dailymotion.com/embed/video/${id}`,
+    allow: 'autoplay; fullscreen; picture-in-picture'
+  },
+  {
+    key: 'spotify',
+    title: 'Spotify media',
+    match (url) {
+      if (normalizeHost(url.hostname) !== 'open.spotify.com') {
+        return null
+      }
+      const match = url.pathname.match(/^\/(artist|album|track)\/([\w-]+)/)
+      return match ? `${match[1]}/${match[2]}` : null
+    },
+    buildSrc: id => `https://open.spotify.com/embed/${id}`,
+    allow: 'autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture'
+  }
+]
+
+module.exports = {
+  resolveEmbed (rawUrl) {
+    const url = parseHttpUrl(rawUrl)
+    if (!url) {
+      return null
+    }
+    for (const provider of PROVIDERS) {
+      const id = provider.match(url)
+      if (id) {
+        return {
+          provider: provider.key,
+          title: provider.title,
+          src: provider.buildSrc(id),
+          allow: provider.allow
+        }
+      }
+    }
+    return null
+  },
+
+  renderEmbeds ($) {
+    $('oembed').each((idx, elm) => {
+      const rawUrl = $(elm).attr('url')
+      const embed = this.resolveEmbed(rawUrl)
+      if (embed) {
+        const wrapper = $('<div>')
+          .addClass(`media-embed is-${embed.provider}`)
+        const iframe = $('<iframe>')
+          .attr('src', embed.src)
+          .attr('title', embed.title)
+          .attr('loading', 'lazy')
+          .attr('allow', embed.allow)
+          .attr('allowfullscreen', '')
+          .attr('referrerpolicy', 'strict-origin-when-cross-origin')
+        wrapper.append(iframe)
+        $(elm).replaceWith(wrapper)
+      } else {
+        const url = parseHttpUrl(rawUrl)
+        if (url) {
+          const link = $('<a>')
+            .attr('href', url.toString())
+            .attr('target', '_blank')
+            .attr('rel', 'noopener noreferrer')
+            .text(rawUrl)
+          $(elm).replaceWith(link)
+        } else {
+          $(elm).replaceWith($('<span>').text('Unsupported media'))
+        }
+      }
+    })
+  }
+}
+
+function parseHttpUrl (rawUrl) {
+  if (!rawUrl) {
+    return null
+  }
+  try {
+    const url = new URL(rawUrl)
+    return ['http:', 'https:'].includes(url.protocol) ? url : null
+  } catch (err) {
+    return null
+  }
+}
+
+function normalizeHost (host) {
+  return host.toLowerCase().replace(/^www\./, '')
+}
+
+function firstPathSegment (url) {
+  return url.pathname.split('/').filter(Boolean)[0] || null
+}
+
+function validMediaId (id) {
+  return id && /^[\w-]+$/.test(id) ? id : null
+}

--- a/server/helpers/page.js
+++ b/server/helpers/page.js
@@ -2,6 +2,7 @@ const qs = require('querystring')
 const _ = require('lodash')
 const crypto = require('crypto')
 const path = require('path')
+const cheerio = require('cheerio')
 
 const localeSegmentRegex = /^[A-Z]{2}(-[A-Z]{2})?$/i
 const localeFolderRegex = /^([a-z]{2}(?:-[a-z]{2})?\/)?(.*)/i
@@ -78,6 +79,46 @@ module.exports = {
       target = `${parsedTarget.pathname}${parsedTarget.search}${parsedTarget.hash}`
     }
     return target
+  },
+  /**
+   * Update rendered internal links after a page is created, moved, or deleted.
+   */
+  updateRenderedPageLinks (render, opts) {
+    const $ = cheerio.load(render, {
+      decodeEntities: true
+    })
+    const fromLocale = opts.mode === 'move' ? opts.sourceLocale : opts.locale
+    const fromPath = opts.mode === 'move' ? opts.sourcePath : opts.path
+    const fromClass = opts.mode === 'create' ? 'is-invalid-page' : 'is-valid-page'
+    const toClass = opts.mode === 'delete' ? 'is-invalid-page' : 'is-valid-page'
+    let changed = false
+
+    $('a.is-internal-link').each((idx, elm) => {
+      const href = $(elm).attr('href')
+      if (!href || !$(elm).hasClass(fromClass)) {
+        return
+      }
+      try {
+        const parsedUrl = new URL(href, 'http://wikijs.local')
+        const page = this.parsePath(parsedUrl.pathname)
+        if (page.locale !== fromLocale || page.path !== fromPath) {
+          return
+        }
+        if (opts.mode === 'move') {
+          const destinationHref = this.getPageHref({ locale: opts.locale, path: opts.path })
+          $(elm).attr('href', `${destinationHref}${parsedUrl.search}${parsedUrl.hash}`)
+        }
+        $(elm).removeClass(fromClass).addClass(toClass)
+        changed = true
+      } catch (err) {
+        // Ignore malformed href values and leave the rendered link untouched.
+      }
+    })
+
+    return {
+      changed,
+      render: decodeBody($)
+    }
   },
   /**
    * Parse raw url path and make it safe
@@ -166,7 +207,7 @@ module.exports = {
     const firstSection = _.head(rawPath.split('/'))
     if (firstSection.length <= 1) {
       return true
-    } else if (localeSegmentRegex.test(firstSection)) {
+    } else if (this.isLocaleSegment(firstSection)) {
       return true
     } else if (
       _.some(WIKI.data.reservedPaths, p => {
@@ -211,4 +252,8 @@ module.exports = {
     }
     return meta
   }
+}
+
+function decodeBody ($) {
+  return $.html('body').replace('<body>', '').replace('</body>', '')
 }

--- a/server/models/pages.js
+++ b/server/models/pages.js
@@ -848,69 +848,32 @@ module.exports = class Page extends Model {
    * @returns {Promise} Promise with no value
    */
   static async reconnectLinks (opts) {
-    const pageHref = pageHelper.getPageHref({ locale: opts.locale, path: opts.path })
-    let replaceArgs = {
-      from: '',
-      to: ''
+    if (!['create', 'move', 'delete'].includes(opts.mode)) {
+      return false
     }
-    switch (opts.mode) {
-      case 'create':
-        replaceArgs.from = `<a href="${pageHref}" class="is-internal-link is-invalid-page">`
-        replaceArgs.to = `<a href="${pageHref}" class="is-internal-link is-valid-page">`
-        break
-      case 'move':
-        const prevPageHref = pageHelper.getPageHref({ locale: opts.sourceLocale, path: opts.sourcePath })
-        replaceArgs.from = `<a href="${prevPageHref}" class="is-internal-link is-valid-page">`
-        replaceArgs.to = `<a href="${pageHref}" class="is-internal-link is-valid-page">`
-        break
-      case 'delete':
-        replaceArgs.from = `<a href="${pageHref}" class="is-internal-link is-valid-page">`
-        replaceArgs.to = `<a href="${pageHref}" class="is-internal-link is-invalid-page">`
-        break
-      default:
-        return false
-    }
+    const lookupPath = opts.mode === 'move' ? opts.sourcePath : opts.path
+    const lookupLocale = opts.mode === 'move' ? opts.sourceLocale : opts.locale
+    const affectedPages = await WIKI.models.pages.query()
+      .column('id', 'hash', 'render')
+      .whereIn('pages.id', function () {
+        this.select('pageLinks.pageId').from('pageLinks').where({
+          'pageLinks.path': lookupPath,
+          'pageLinks.localeCode': lookupLocale
+        })
+      })
 
-    let affectedHashes = []
-    // -> Perform replace and return affected page hashes (POSTGRES only)
-    if (WIKI.config.db.type === 'postgres') {
-      const qryHashes = await WIKI.models.pages.query()
-        .returning('hash')
-        .patch({
-          render: WIKI.models.knex.raw('REPLACE(??, ?, ?)', ['render', replaceArgs.from, replaceArgs.to])
-        })
-        .whereIn('pages.id', function () {
-          this.select('pageLinks.pageId').from('pageLinks').where({
-            'pageLinks.path': opts.path,
-            'pageLinks.localeCode': opts.locale
-          })
-        })
-      affectedHashes = qryHashes.map(h => h.hash)
-    } else {
-      // -> Perform replace, then query affected page hashes (MYSQL, MARIADB, MSSQL, SQLITE only)
-      await WIKI.models.pages.query()
-        .patch({
-          render: WIKI.models.knex.raw('REPLACE(??, ?, ?)', ['render', replaceArgs.from, replaceArgs.to])
-        })
-        .whereIn('pages.id', function () {
-          this.select('pageLinks.pageId').from('pageLinks').where({
-            'pageLinks.path': opts.path,
-            'pageLinks.localeCode': opts.locale
-          })
-        })
-      const qryHashes = await WIKI.models.pages.query()
-        .column('hash')
-        .whereIn('pages.id', function () {
-          this.select('pageLinks.pageId').from('pageLinks').where({
-            'pageLinks.path': opts.path,
-            'pageLinks.localeCode': opts.locale
-          })
-        })
-      affectedHashes = qryHashes.map(h => h.hash)
+    for (const page of affectedPages) {
+      const updated = pageHelper.updateRenderedPageLinks(page.render, opts)
+      if (updated.changed) {
+        await WIKI.models.pages.query().patch({ render: updated.render }).findById(page.id)
+        await WIKI.models.pages.deletePageFromCache(page.hash)
+        WIKI.events.outbound.emit('deletePageFromCache', page.hash)
+      }
     }
-    for (const hash of affectedHashes) {
-      await WIKI.models.pages.deletePageFromCache(hash)
-      WIKI.events.outbound.emit('deletePageFromCache', hash)
+    if (opts.mode === 'move') {
+      await WIKI.models.pageLinks.query()
+        .patch({ path: opts.path, localeCode: opts.locale })
+        .where({ path: opts.sourcePath, localeCode: opts.sourceLocale })
     }
   }
 

--- a/server/modules/rendering/html-core/renderer.js
+++ b/server/modules/rendering/html-core/renderer.js
@@ -2,6 +2,7 @@ const _ = require('lodash')
 const cheerio = require('cheerio')
 const uslug = require('uslug')
 const pageHelper = require('../../../helpers/page')
+const mediaHelper = require('../../../helpers/media')
 const URL = require('url').URL
 
 const mustacheRegExp = /(\{|&#x7b;?){2}(.+?)(\}|&#x7d;?){2}/i
@@ -263,6 +264,12 @@ module.exports = {
     $ = cheerio.load(output, {
       decodeEntities: true
     })
+
+    // --------------------------------
+    // Render trusted WYSIWYG media embeds
+    // --------------------------------
+
+    mediaHelper.renderEmbeds($)
 
     function iterateMustacheNode (node) {
       $(node).contents().each((idx, item) => {

--- a/server/modules/rendering/html-security/renderer.js
+++ b/server/modules/rendering/html-security/renderer.js
@@ -7,8 +7,8 @@ module.exports = {
       const window = new JSDOM('').window
       const DOMPurify = createDOMPurify(window)
 
-      const allowedAttrs = ['v-pre', 'v-slot:tabs', 'v-slot:content', 'target']
-      const allowedTags = ['tabset', 'template']
+      const allowedAttrs = ['v-pre', 'v-slot:tabs', 'v-slot:content', 'target', 'url']
+      const allowedTags = ['tabset', 'template', 'oembed']
 
       if (config.allowDrawIoUnsafe) {
         allowedTags.push('foreignObject')

--- a/server/test/helpers/common.test.js
+++ b/server/test/helpers/common.test.js
@@ -1,0 +1,24 @@
+const commonHelper = require('../../helpers/common')
+
+beforeEach(() => {
+  global.WIKI = {
+    config: {
+      host: 'https://wiki.example.com'
+    }
+  }
+})
+
+describe('helpers/common/getCookieOpts', () => {
+  it('sets a persistent expiration for normal authentication cookies', () => {
+    expect(commonHelper.getCookieOpts()).toMatchObject({
+      secure: true,
+      expires: expect.any(Date)
+    })
+  })
+
+  it('omits the future expiration when clearing authentication cookies', () => {
+    expect(commonHelper.getCookieOpts({ persistent: false })).toEqual({
+      secure: true
+    })
+  })
+})

--- a/server/test/helpers/media.test.js
+++ b/server/test/helpers/media.test.js
@@ -1,0 +1,50 @@
+const cheerio = require('cheerio')
+const mediaHelper = require('../../helpers/media')
+
+describe('helpers/media/resolveEmbed', () => {
+  test.each([
+    ['https://www.youtube.com/watch?v=dQw4w9WgXcQ', 'youtube', 'https://www.youtube.com/embed/dQw4w9WgXcQ'],
+    ['https://youtu.be/dQw4w9WgXcQ', 'youtube', 'https://www.youtube.com/embed/dQw4w9WgXcQ'],
+    ['https://vimeo.com/channels/staffpicks/243244233', 'vimeo', 'https://player.vimeo.com/video/243244233'],
+    ['https://www.dailymotion.com/video/x9abcd', 'dailymotion', 'https://www.dailymotion.com/embed/video/x9abcd'],
+    ['https://open.spotify.com/track/abc123', 'spotify', 'https://open.spotify.com/embed/track/abc123']
+  ])('resolves %s to a trusted embed URL', (url, provider, src) => {
+    expect(mediaHelper.resolveEmbed(url)).toMatchObject({ provider, src })
+  })
+
+  it('rejects non-HTTP and untrusted embed URLs', () => {
+    expect(mediaHelper.resolveEmbed('javascript:alert(1)')).toBeNull()
+    expect(mediaHelper.resolveEmbed('https://example.com/video/123')).toBeNull()
+    expect(mediaHelper.resolveEmbed('https://youtu.be/%22%3E%3Cscript%3Ealert(1)%3C/script%3E')).toBeNull()
+  })
+})
+
+describe('helpers/media/renderEmbeds', () => {
+  it('renders a responsive iframe for a trusted provider', () => {
+    const $ = cheerio.load('<figure class="media"><oembed url="https://vimeo.com/243244233"></oembed></figure>')
+
+    mediaHelper.renderEmbeds($)
+
+    expect($('.media-embed.is-vimeo iframe').attr('src')).toBe('https://player.vimeo.com/video/243244233')
+    expect($('.media-embed.is-vimeo iframe').attr('allowfullscreen')).toBe('')
+    expect($('oembed')).toHaveLength(0)
+  })
+
+  it('renders unsupported HTTP providers as safe links', () => {
+    const $ = cheerio.load('<oembed url="https://example.com/media/123"></oembed>')
+
+    mediaHelper.renderEmbeds($)
+
+    expect($('a').attr('href')).toBe('https://example.com/media/123')
+    expect($('a').attr('rel')).toBe('noopener noreferrer')
+  })
+
+  it('does not turn unsafe URLs into links or iframes', () => {
+    const $ = cheerio.load('<oembed url="javascript:alert(1)"></oembed>')
+
+    mediaHelper.renderEmbeds($)
+
+    expect($('iframe, a')).toHaveLength(0)
+    expect($('span').text()).toBe('Unsupported media')
+  })
+})

--- a/server/test/helpers/page.test.js
+++ b/server/test/helpers/page.test.js
@@ -9,6 +9,9 @@ beforeEach(() => {
         namespacing: false,
         namespaces: ['en', 'fr']
       }
+    },
+    data: {
+      reservedPaths: ['login']
     }
   }
 })
@@ -90,6 +93,14 @@ describe('helpers/page/parsePath', () => {
       explicitLocale: true
     })
   })
+
+  it('allows unconfigured two-letter folders', () => {
+    expect(pageHelper.isReservedPath('db/postgres')).toBe(false)
+  })
+
+  it('continues to reserve configured locale prefixes', () => {
+    expect(pageHelper.isReservedPath('fr/guide')).toBe(true)
+  })
 })
 
 describe('helpers/page/resolvePageHref', () => {
@@ -140,5 +151,46 @@ describe('helpers/page/resolveNavigationHref', () => {
       targetType: 'search',
       locale: 'en'
     })).toBe('release notes')
+  })
+})
+
+describe('helpers/page/updateRenderedPageLinks', () => {
+  it('validates links while preserving query strings, fragments, and other attributes', () => {
+    const result = pageHelper.updateRenderedPageLinks(
+      '<p><a title="More" href="/guide/next?view=compact#part" class="is-internal-link is-invalid-page">Next</a></p>',
+      { mode: 'create', locale: 'en', path: 'guide/next' }
+    )
+
+    expect(result.changed).toBe(true)
+    expect(result.render).toContain('href="/guide/next?view=compact#part"')
+    expect(result.render).toContain('title="More"')
+    expect(result.render).toContain('is-internal-link is-valid-page')
+  })
+
+  it('moves links while preserving query strings and fragments', () => {
+    const result = pageHelper.updateRenderedPageLinks(
+      '<a href="/guide/old?view=compact#part" class="is-internal-link is-valid-page">Old</a>',
+      {
+        mode: 'move',
+        sourceLocale: 'en',
+        sourcePath: 'guide/old',
+        locale: 'en',
+        path: 'docs/new'
+      }
+    )
+
+    expect(result.changed).toBe(true)
+    expect(result.render).toContain('href="/docs/new?view=compact#part"')
+    expect(result.render).toContain('is-internal-link is-valid-page')
+  })
+
+  it('invalidates links when a page is deleted', () => {
+    const result = pageHelper.updateRenderedPageLinks(
+      '<a href="/guide/old" class="is-internal-link is-valid-page">Old</a>',
+      { mode: 'delete', locale: 'en', path: 'guide/old' }
+    )
+
+    expect(result.changed).toBe(true)
+    expect(result.render).toContain('is-internal-link is-invalid-page')
   })
 })

--- a/server/test/modules/rendering/html-core.test.js
+++ b/server/test/modules/rendering/html-core.test.js
@@ -1,0 +1,62 @@
+const htmlCoreRenderer = require('../../../modules/rendering/html-core/renderer')
+
+beforeEach(() => {
+  global.WIKI = {
+    config: {
+      host: 'https://wiki.example.com',
+      lang: {
+        code: 'en',
+        namespacing: false,
+        namespaces: ['en']
+      }
+    },
+    logger: {
+      warn: jest.fn()
+    }
+  }
+})
+
+const render = input => htmlCoreRenderer.render.call({
+  input,
+  page: {
+    id: 1,
+    localeCode: 'en',
+    path: 'home',
+    $relatedQuery: jest.fn().mockResolvedValue([])
+  },
+  config: {
+    absoluteLinks: false,
+    openExternalLinkNewTab: false,
+    relAttributeExternalLink: 'noreferrer'
+  },
+  children: [{
+    key: 'htmlSecurity',
+    step: 'post',
+    config: {
+      safeHTML: true,
+      allowDrawIoUnsafe: false,
+      allowIFrames: false
+    }
+  }]
+})
+
+describe('rendering/html-core media embeds', () => {
+  it('renders a sanitized CKEditor media element using a trusted provider iframe', async () => {
+    const output = await render(
+      '<figure class="media"><oembed url="https://www.youtube.com/watch?v=dQw4w9WgXcQ"></oembed></figure>'
+    )
+
+    expect(output).toContain('class="media-embed is-youtube"')
+    expect(output).toContain('src="https://www.youtube.com/embed/dQw4w9WgXcQ"')
+    expect(output).not.toContain('<oembed')
+  })
+
+  it('does not render an iframe for an unsafe media URL', async () => {
+    const output = await render(
+      '<figure class="media"><oembed url="javascript:alert(1)"></oembed></figure>'
+    )
+
+    expect(output).toContain('Unsupported media')
+    expect(output).not.toContain('<iframe')
+  })
+})

--- a/server/test/modules/rendering/html-security.test.js
+++ b/server/test/modules/rendering/html-security.test.js
@@ -1,0 +1,13 @@
+const htmlSecurityRenderer = require('../../../modules/rendering/html-security/renderer')
+
+describe('rendering/html-security', () => {
+  it('preserves inert CKEditor media metadata for trusted post-processing', async () => {
+    const output = await htmlSecurityRenderer.init(
+      '<figure class="media"><oembed url="https://www.youtube.com/watch?v=dQw4w9WgXcQ"></oembed></figure>',
+      { safeHTML: true, allowDrawIoUnsafe: false, allowIFrames: false }
+    )
+
+    expect(output).toContain('<oembed url="https://www.youtube.com/watch?v=dQw4w9WgXcQ"></oembed>')
+    expect(output).not.toContain('<iframe')
+  })
+})


### PR DESCRIPTION
## Summary

- restore trusted WYSIWYG media embeds
- keep rendered internal links accurate after page creation, moves, and deletion
- distinguish configured locales from ordinary two-letter folders
- clear invalid JWT cookies without retaining a future expiration

## Verification

- `yarn jest --runInBand server/test/helpers/common.test.js server/test/helpers/media.test.js server/test/helpers/page.test.js server/test/modules/rendering/html-core.test.js server/test/modules/rendering/html-security.test.js` (30 tests passed)
- ESLint passed for all affected JavaScript files
- `git diff --check origin/main...HEAD` passed