### PR TITLE
Fix remaining V2 content data integrity issues

### DIFF
--- a/server/graph/resolvers/asset.js
+++ b/server/graph/resolvers/asset.js
@@ -127,6 +127,12 @@ module.exports = {
           // Delete old asset cache
           await asset.deleteAssetCache()
 
+          // Update HTML page references to the renamed asset
+          await WIKI.models.pages.renameAssetReferences({
+            sourcePath: assetSourcePath,
+            destinationPath: assetTargetPath
+          })
+
           // Rename in Storage
           await WIKI.models.storage.assetEvent({
             event: 'renamed',

--- a/server/helpers/asset.js
+++ b/server/helpers/asset.js
@@ -1,6 +1,7 @@
 const crypto = require('crypto')
 const path = require('path')
 const sanitize = require('sanitize-filename')
+const cheerio = require('cheerio')
 
 module.exports = {
   /**
@@ -19,5 +20,53 @@ module.exports = {
    */
   sanitizeFilename(filename) {
     return sanitize(filename.toLowerCase().replace(/[\s,;#()[\]]+/g, '_'))
+  },
+
+  /**
+   * Rewrite root-relative asset references in an HTML fragment.
+   */
+  rewriteHtmlReferences (html, sourcePath, destinationPath) {
+    if (!html) {
+      return { changed: false, html }
+    }
+    const sourceHref = normalizeAssetPath(sourcePath)
+    const destinationHref = normalizeAssetPath(destinationPath)
+    const $ = cheerio.load(html, { decodeEntities: false }, false)
+    let changed = false
+
+    $('[src], [href]').each((idx, elm) => {
+      for (const attr of ['src', 'href']) {
+        const value = $(elm).attr(attr)
+        const replacement = rewriteAssetUrl(value, sourceHref, destinationHref)
+        if (replacement !== value) {
+          $(elm).attr(attr, replacement)
+          changed = true
+        }
+      }
+    })
+
+    return {
+      changed,
+      html: changed ? $.html() : html
+    }
+  }
+}
+
+function normalizeAssetPath (assetPath) {
+  return `/${String(assetPath || '').replace(/^\/+/, '')}`
+}
+
+function rewriteAssetUrl (value, sourceHref, destinationHref) {
+  if (!value || !value.startsWith('/') || value.startsWith('//')) {
+    return value
+  }
+  try {
+    const parsed = new URL(value, 'http://wikijs.local')
+    if (decodeURIComponent(parsed.pathname) !== sourceHref) {
+      return value
+    }
+    return `${destinationHref}${parsed.search}${parsed.hash}`
+  } catch (err) {
+    return value
   }
 }

--- a/server/helpers/page.js
+++ b/server/helpers/page.js
@@ -201,6 +201,15 @@ module.exports = {
     }
   },
   /**
+   * Normalize source timestamps parsed from page front matter.
+   */
+  getSourceTimestamps (metadata = {}) {
+    return _.pickBy({
+      createdAt: normalizeTimestamp(metadata.dateCreated),
+      updatedAt: normalizeTimestamp(metadata.date)
+    }, Boolean)
+  },
+  /**
    * Check if path is a reserved path
    */
   isReservedPath(rawPath) {
@@ -256,4 +265,12 @@ module.exports = {
 
 function decodeBody ($) {
   return $.html('body').replace('<body>', '').replace('</body>', '')
+}
+
+function normalizeTimestamp (value) {
+  if (_.isNil(value) || value === '') {
+    return null
+  }
+  const date = value instanceof Date ? value : new Date(value)
+  return Number.isNaN(date.getTime()) ? null : date.toISOString()
 }

--- a/server/models/pages.js
+++ b/server/models/pages.js
@@ -12,6 +12,7 @@ const CleanCSS = require('clean-css')
 const TurndownService = require('turndown')
 const turndownPluginGfm = require('@joplin/turndown-plugin-gfm').gfm
 const cheerio = require('cheerio')
+const assetHelper = require('../helpers/asset')
 
 /* global WIKI */
 
@@ -358,6 +359,8 @@ module.exports = class Page extends Model {
     // -> Get latest updatedAt
     page.updatedAt = await WIKI.models.pages.query().findById(page.id).select('updatedAt').then(r => r.updatedAt)
 
+    await WIKI.models.pages.applySourceTimestamps(page, opts)
+
     return page
   }
 
@@ -485,6 +488,21 @@ module.exports = class Page extends Model {
     // -> Get latest updatedAt
     page.updatedAt = await WIKI.models.pages.query().findById(page.id).select('updatedAt').then(r => r.updatedAt)
 
+    await WIKI.models.pages.applySourceTimestamps(page, opts)
+
+    return page
+  }
+
+  /**
+   * Restore source timestamps after import-time rendering and hooks have run.
+   */
+  static async applySourceTimestamps (page, opts) {
+    const timestamps = _.pickBy(_.pick(opts, ['createdAt', 'updatedAt']), Boolean)
+    if (_.isEmpty(timestamps)) {
+      return page
+    }
+    await WIKI.models.knex('pages').where('id', page.id).update(timestamps)
+    Object.assign(page, timestamps)
     return page
   }
 
@@ -809,8 +827,11 @@ module.exports = class Page extends Model {
       versionDate: page.updatedAt
     })
 
+    const relatedTags = await WIKI.models.pages.relatedQuery('tags').for(page.id).select('tags.id')
+
     // -> Delete page
     await WIKI.models.pages.query().delete().where('id', page.id)
+    await WIKI.models.tags.deleteOrphans(_.map(relatedTags, 'id'))
     await WIKI.models.pages.deletePageFromCache(page.hash)
     WIKI.events.outbound.emit('deletePageFromCache', page.hash)
 
@@ -834,6 +855,33 @@ module.exports = class Page extends Model {
       path: page.path,
       mode: 'delete'
     })
+  }
+
+  /**
+   * Rewrite stored HTML references after an asset is renamed.
+   */
+  static async renameAssetReferences ({ sourcePath, destinationPath }) {
+    const pages = await WIKI.models.pages.query()
+      .select('id', 'hash', 'content', 'render')
+      .where('contentType', 'html')
+    let affected = 0
+
+    for (const page of pages) {
+      const content = assetHelper.rewriteHtmlReferences(page.content, sourcePath, destinationPath)
+      const render = assetHelper.rewriteHtmlReferences(page.render, sourcePath, destinationPath)
+      if (!content.changed && !render.changed) {
+        continue
+      }
+      await WIKI.models.knex('pages').where('id', page.id).update({
+        ...(content.changed ? { content: content.html } : {}),
+        ...(render.changed ? { render: render.html } : {})
+      })
+      await WIKI.models.pages.deletePageFromCache(page.hash)
+      WIKI.events.outbound.emit('deletePageFromCache', page.hash)
+      affected++
+    }
+
+    return affected
   }
 
   /**

--- a/server/models/tags.js
+++ b/server/models/tags.js
@@ -98,8 +98,23 @@ module.exports = class Tag extends Model {
     const tagsToUnrelate = _.differenceBy(currentTags, targetTags, 'id')
     if (tagsToUnrelate.length > 0) {
       await page.$relatedQuery('tags').unrelate().whereIn('tags.id', _.map(tagsToUnrelate, 'id'))
+      await WIKI.models.tags.deleteOrphans(_.map(tagsToUnrelate, 'id'))
     }
 
     page.tags = targetTags
+  }
+
+  /**
+   * Delete tag rows that are no longer associated with any current page.
+   */
+  static async deleteOrphans (tagIds = []) {
+    const candidates = _.uniq(tagIds).filter(_.isSafeInteger)
+    if (candidates.length < 1) {
+      return 0
+    }
+    return WIKI.models.tags.query()
+      .delete()
+      .whereIn('id', candidates)
+      .whereNotIn('id', WIKI.models.knex('pageTags').select('tagId'))
   }
 }

--- a/server/modules/storage/disk/common.js
+++ b/server/modules/storage/disk/common.js
@@ -80,6 +80,7 @@ module.exports = {
       locale: contentPath.locale
     })
     const newTags = !_.isNil(pageData.tags) ? _.get(pageData, 'tags', '').split(', ') : false
+    const sourceTimestamps = pageHelper.getSourceTimestamps(pageData)
     if (currentPage) {
       // Already in the DB, can mark as modified
       WIKI.logger.info(`(STORAGE/${moduleName}) Page marked as modified: ${normalizedRelPath}`)
@@ -91,6 +92,7 @@ module.exports = {
         isPublished: _.get(pageData, 'isPublished', currentPage.isPublished),
         isPrivate: false,
         content: pageData.content,
+        ...sourceTimestamps,
         user: user,
         skipStorage: true
       })
@@ -107,6 +109,7 @@ module.exports = {
         isPublished: _.get(pageData, 'isPublished', true),
         isPrivate: false,
         content: pageData.content,
+        ...sourceTimestamps,
         user: user,
         editor: pageEditor,
         skipStorage: true

--- a/server/test/helpers/asset.test.js
+++ b/server/test/helpers/asset.test.js
@@ -13,3 +13,25 @@ describe('helpers/asset/sanitizeFilename', () => {
     expect(assetHelper.sanitizeFilename('folder/file?.png')).toBe('folderfile.png')
   })
 })
+
+describe('helpers/asset/rewriteHtmlReferences', () => {
+  it('updates image and download references while preserving query strings and fragments', () => {
+    const result = assetHelper.rewriteHtmlReferences(
+      '<figure><img src="/images/old.png?size=large#preview"></figure><a href="/images/old.png">Download</a>',
+      'images/old.png',
+      'images/new.png'
+    )
+
+    expect(result.changed).toBe(true)
+    expect(result.html).toContain('src="/images/new.png?size=large#preview"')
+    expect(result.html).toContain('href="/images/new.png"')
+  })
+
+  it('leaves external and similarly named assets unchanged', () => {
+    const html = '<img src="https://cdn.example.com/images/old.png"><img src="/images/old.png.bak">'
+    expect(assetHelper.rewriteHtmlReferences(html, 'images/old.png', 'images/new.png')).toEqual({
+      changed: false,
+      html
+    })
+  })
+})

--- a/server/test/helpers/page.test.js
+++ b/server/test/helpers/page.test.js
@@ -77,6 +77,22 @@ TEST CONTENT`
   })
 })
 
+describe('helpers/page/getSourceTimestamps', () => {
+  it('normalizes YAML dates for imported pages', () => {
+    expect(pageHelper.getSourceTimestamps({
+      dateCreated: new Date('2020-01-02T03:04:05Z'),
+      date: '2021-02-03T04:05:06+02:00'
+    })).toEqual({
+      createdAt: '2020-01-02T03:04:05.000Z',
+      updatedAt: '2021-02-03T02:05:06.000Z'
+    })
+  })
+
+  it('ignores missing and invalid source dates', () => {
+    expect(pageHelper.getSourceTimestamps({ date: 'not-a-date' })).toEqual({})
+  })
+})
+
 describe('helpers/page/parsePath', () => {
   it('does not mistake an arbitrary two-letter folder for a locale', () => {
     expect(pageHelper.parsePath('/db/postgres')).toMatchObject({


### PR DESCRIPTION
## Summary

Implements the content/data-integrity group from `OPEN_V2_ISSUES.md`:

- #4631: preserve valid `dateCreated` and `date` front-matter timestamps during disk and Git-backed imports
- #1222: rewrite stored HTML image/download references after an asset rename and invalidate affected page caches
- #1105: remove tag rows after their final current-page association is removed

## Verification

- `yarn jest --runInBand server/test` — 10 suites, 48 tests passed
- `yarn pug-lint server/views`
- ESLint passed on every changed JavaScript file
- `git diff --check`

The local tracking document and reproduction image are intentionally not included.