### PR TITLE
Complete V2 account recovery and logout flows

### DIFF
--- a/client/components/admin/admin-security.vue
+++ b/client/components/admin/admin-security.vue
@@ -196,6 +196,15 @@
                     persistent-hint
                     :hint='$t(`admin:security.hideLocalLoginHint`)'
                     )
+                  v-switch(
+                    inset
+                    label='Redirect to login after logout'
+                    color='primary'
+                    v-model='config.authRedirectToLoginAfterLogout'
+                    prepend-icon='mdi-logout-variant'
+                    persistent-hint
+                    hint='Return users to the login screen after local logout. External provider logout redirects are preserved.'
+                    )
                 v-divider.mt-3
                 .overline.grey--text.pa-4 {{$t('admin:security.loginSecurity')}}
                 .px-4.pb-3
@@ -274,6 +283,7 @@ export default {
         authAutoLogin: false,
         authHideLocal: false,
         authLoginBgUrl: '',
+        authRedirectToLoginAfterLogout: false,
         authJwtAudience: 'urn:wiki.js',
         authJwtExpiration: '30m',
         authJwtRenewablePeriod: '14d'
@@ -301,6 +311,7 @@ export default {
               $authEnforce2FA: Boolean
               $authHideLocal: Boolean
               $authLoginBgUrl: String
+              $authRedirectToLoginAfterLogout: Boolean
               $authJwtAudience: String
               $authJwtExpiration: String
               $authJwtRenewablePeriod: String
@@ -324,6 +335,7 @@ export default {
                   authEnforce2FA: $authEnforce2FA,
                   authHideLocal: $authHideLocal,
                   authLoginBgUrl: $authLoginBgUrl,
+                  authRedirectToLoginAfterLogout: $authRedirectToLoginAfterLogout,
                   authJwtAudience: $authJwtAudience,
                   authJwtExpiration: $authJwtExpiration,
                   authJwtRenewablePeriod: $authJwtRenewablePeriod,
@@ -356,6 +368,7 @@ export default {
             authEnforce2FA: _.get(this.config, 'authEnforce2FA', false),
             authHideLocal: _.get(this.config, 'authHideLocal', false),
             authLoginBgUrl: _.get(this.config, 'authLoginBgUrl', ''),
+            authRedirectToLoginAfterLogout: _.get(this.config, 'authRedirectToLoginAfterLogout', false),
             authJwtAudience: _.get(this.config, 'authJwtAudience', ''),
             authJwtExpiration: _.get(this.config, 'authJwtExpiration', ''),
             authJwtRenewablePeriod: _.get(this.config, 'authJwtRenewablePeriod', ''),
@@ -409,6 +422,7 @@ export default {
               authEnforce2FA
               authHideLocal
               authLoginBgUrl
+              authRedirectToLoginAfterLogout
               authJwtAudience
               authJwtExpiration
               authJwtRenewablePeriod

--- a/client/components/login.vue
+++ b/client/components/login.vue
@@ -90,6 +90,14 @@
                 href='#forgot'
                 ): .caption {{ $t('auth:forgotPasswordLink') }}
               v-btn.text-none(
+                v-if='selectedStrategyKey === `local`'
+                text
+                rounded
+                color='grey darken-3'
+                @click.stop.prevent='resendVerification'
+                href='#verify'
+                ): .caption Resend verification email
+              v-btn.text-none(
                 v-if='selectedStrategyKey === `local` && selectedStrategy.selfRegistration'
                 color='indigo darken-2'
                 text
@@ -133,6 +141,45 @@
                 color='grey darken-3'
                 @click.stop.prevent='screen = `login`'
                 href='#forgot'
+                ): .caption {{ $t('auth:forgotPasswordCancel') }}
+        //-------------------------------------------------
+        //- RESEND VERIFICATION FORM
+        //-------------------------------------------------
+        template(v-if='screen === `resendVerification`')
+          .login-subtitle
+            .text-subtitle-1 Resend verification email
+          .login-info Enter the email address used to register. If it belongs to an unverified account, a new link will be sent.
+          .login-form
+            v-text-field(
+              solo
+              flat
+              prepend-inner-icon='mdi-clipboard-account'
+              background-color='white'
+              color='blue darken-2'
+              hide-details
+              ref='iptVerificationEmail'
+              v-model='username'
+              :placeholder='$t(`auth:fields.email`)'
+              type='email'
+              autocomplete='email'
+              light
+              @keyup.enter='resendVerificationSubmit'
+              )
+            v-btn.mt-2.text-none(
+              width='100%'
+              large
+              color='blue darken-2'
+              dark
+              @click='resendVerificationSubmit'
+              :loading='isLoading'
+              ) Send verification email
+            .text-center.mt-5
+              v-btn.text-none(
+                text
+                rounded
+                color='grey darken-3'
+                @click.stop.prevent='screen = `login`'
+                href='#login'
                 ): .caption {{ $t('auth:forgotPasswordCancel') }}
         //-------------------------------------------------
         //- CHANGE PASSWORD FORM
@@ -558,6 +605,59 @@ export default {
       this.$nextTick(() => {
         this.$refs.iptForgotPwdEmail.focus()
       })
+    },
+    /**
+     * SWITCH TO RESEND VERIFICATION SCREEN
+     */
+    resendVerification () {
+      this.screen = 'resendVerification'
+      this.$nextTick(() => {
+        this.$refs.iptVerificationEmail.focus()
+      })
+    },
+    /**
+     * RESEND VERIFICATION SUBMIT
+     */
+    async resendVerificationSubmit () {
+      this.loaderColor = 'grey darken-4'
+      this.loaderTitle = 'Sending verification email...'
+      this.isLoading = true
+      try {
+        const resp = await this.$apollo.mutate({
+          mutation: gql`
+            mutation ($email: String!) {
+              authentication {
+                resendVerification(email: $email) {
+                  responseResult {
+                    succeeded
+                    message
+                  }
+                }
+              }
+            }
+          `,
+          variables: {
+            email: this.username
+          }
+        })
+        const result = _.get(resp, 'data.authentication.resendVerification.responseResult', {})
+        if (!result.succeeded) {
+          throw new Error(result.message || this.$t('auth:genericError'))
+        }
+        this.$store.commit('showNotification', {
+          style: 'success',
+          message: 'If the account is awaiting verification, a new email has been sent.',
+          icon: 'email'
+        })
+        this.screen = 'login'
+      } catch (err) {
+        this.$store.commit('showNotification', {
+          style: 'red',
+          message: err.message,
+          icon: 'alert'
+        })
+      }
+      this.isLoading = false
     },
     /**
      * FORGOT PASSWORD SUBMIT

--- a/server/app/data.yml
+++ b/server/app/data.yml
@@ -66,6 +66,7 @@ defaults:
       enforce2FA: false
       hideLocal: false
       loginBgUrl: ''
+      redirectToLoginAfterLogout: false
       audience: 'urn:wiki.js'
       tokenExpiration: '30m'
       tokenRenewal: '14d'

--- a/server/graph/resolvers/authentication.js
+++ b/server/graph/resolvers/authentication.js
@@ -151,6 +151,19 @@ module.exports = {
       }
     },
     /**
+     * Resend an account verification email
+     */
+    async resendVerification (obj, args, context) {
+      try {
+        await WIKI.models.users.loginResendVerification(args, context)
+        return {
+          responseResult: graphHelper.generateSuccess('Verification request processed.')
+        }
+      } catch (err) {
+        return graphHelper.generateError(err)
+      }
+    },
+    /**
      * Register a new account
      */
     async register (obj, args, context) {

--- a/server/graph/resolvers/site.js
+++ b/server/graph/resolvers/site.js
@@ -28,6 +28,7 @@ module.exports = {
         authEnforce2FA: WIKI.config.auth.enforce2FA,
         authHideLocal: WIKI.config.auth.hideLocal,
         authLoginBgUrl: WIKI.config.auth.loginBgUrl,
+        authRedirectToLoginAfterLogout: WIKI.config.auth.redirectToLoginAfterLogout,
         authJwtAudience: WIKI.config.auth.audience,
         authJwtExpiration: WIKI.config.auth.tokenExpiration,
         authJwtRenewablePeriod: WIKI.config.auth.tokenRenewal,
@@ -85,6 +86,7 @@ module.exports = {
           enforce2FA: _.get(args, 'authEnforce2FA', WIKI.config.auth.enforce2FA),
           hideLocal: _.get(args, 'authHideLocal', WIKI.config.auth.hideLocal),
           loginBgUrl: _.get(args, 'authLoginBgUrl', WIKI.config.auth.loginBgUrl),
+          redirectToLoginAfterLogout: _.get(args, 'authRedirectToLoginAfterLogout', WIKI.config.auth.redirectToLoginAfterLogout),
           audience: _.get(args, 'authJwtAudience', WIKI.config.auth.audience),
           tokenExpiration: _.get(args, 'authJwtExpiration', WIKI.config.auth.tokenExpiration),
           tokenRenewal: _.get(args, 'authJwtRenewablePeriod', WIKI.config.auth.tokenRenewal)

--- a/server/graph/schemas/authentication.graphql
+++ b/server/graph/schemas/authentication.graphql
@@ -59,6 +59,10 @@ type AuthenticationMutation {
     email: String!
   ): DefaultResponse @rateLimit(limit: 3, duration: 60)
 
+  resendVerification(
+    email: String!
+  ): DefaultResponse @rateLimit(limit: 3, duration: 60)
+
   register(
     email: String!
     password: String!

--- a/server/graph/schemas/site.graphql
+++ b/server/graph/schemas/site.graphql
@@ -39,6 +39,7 @@ type SiteMutation {
     authEnforce2FA: Boolean
     authHideLocal: Boolean
     authLoginBgUrl: String
+    authRedirectToLoginAfterLogout: Boolean
     authJwtAudience: String
     authJwtExpiration: String
     authJwtRenewablePeriod: String
@@ -89,6 +90,7 @@ type SiteConfig {
   authEnforce2FA: Boolean
   authHideLocal: Boolean
   authLoginBgUrl: String
+  authRedirectToLoginAfterLogout: Boolean
   authJwtAudience: String
   authJwtExpiration: String
   authJwtRenewablePeriod: String

--- a/server/models/users.js
+++ b/server/models/users.js
@@ -162,7 +162,7 @@ module.exports = class User extends Model {
   // Model Methods
   // ------------------------------------------------
 
-  static async processProfile({ profile, providerKey }) {
+  static async processProfile({ profile, providerKey, relinkByEmail = false }) {
     const provider = _.get(WIKI.auth.strategies, providerKey, {})
     provider.info = _.find(WIKI.data.authentication, ['key', provider.stategyKey])
 
@@ -195,6 +195,21 @@ module.exports = class User extends Model {
       user = await WIKI.models.users.query().findOne({
         email: primaryEmail,
         providerId: null,
+        providerKey
+      })
+      if (user) {
+        user = await user.$query().patchAndFetch({
+          providerId: _.toString(profile.id)
+        })
+      }
+    }
+
+    // Relink an existing account after an identity provider changes its
+    // subject identifier. Providers must opt in because email ownership is
+    // the trust boundary for this recovery behavior.
+    if (!user && relinkByEmail && !_.isNil(profile.id)) {
+      user = await WIKI.models.users.query().findOne({
+        email: primaryEmail,
         providerKey
       })
       if (user) {
@@ -556,6 +571,56 @@ module.exports = class User extends Model {
   }
 
   /**
+   * Send a replacement account verification email without revealing whether
+   * the supplied address belongs to an unverified account.
+   */
+  static async loginResendVerification ({ email }) {
+    email = _.toLower(_.trim(email))
+    const usr = await WIKI.models.users.query().where({
+      email,
+      providerKey: 'local'
+    }).first()
+    if (!usr || !usr.isActive || usr.isVerified) {
+      WIKI.logger.debug(`Verification resend request for ineligible local account ${email}: [DISCARDED]`)
+      return
+    }
+
+    const verificationToken = await WIKI.models.userKeys.generateToken({
+      kind: 'verify',
+      userId: usr.id
+    })
+    try {
+      await WIKI.models.users.sendVerificationEmail({
+        email: usr.email,
+        verificationToken
+      })
+      await WIKI.models.userKeys.query()
+        .delete()
+        .where({ userId: usr.id, kind: 'verify' })
+        .whereNot('token', verificationToken)
+    } catch (mailErr) {
+      await WIKI.models.userKeys.destroyToken({ token: verificationToken })
+      WIKI.logger.warn(`Account verification email could not be resent: ${mailErr.message}`)
+    }
+  }
+
+  static async sendVerificationEmail ({ email, verificationToken }) {
+    await WIKI.mail.send({
+      template: 'accountVerify',
+      to: email,
+      subject: 'Verify your account',
+      data: {
+        preheadertext: 'Verify your account in order to gain access to the wiki.',
+        title: 'Verify your account',
+        content: 'Click the button below in order to verify your account and gain access to the wiki.',
+        buttonLink: `${WIKI.config.host}/verify/${verificationToken}`,
+        buttonText: 'Verify'
+      },
+      text: `You must open the following link in your browser to verify your account and gain access to the wiki: ${WIKI.config.host}/verify/${verificationToken}`
+    })
+  }
+
+  /**
    * Create a new user
    *
    * @param {Object} param0 User Fields
@@ -856,18 +921,9 @@ module.exports = class User extends Model {
             // Send verification email. Recipient-specific SMTP failures must not
             // disclose whether an address exists on an allowed domain.
             try {
-              await WIKI.mail.send({
-                template: 'accountVerify',
-                to: email,
-                subject: 'Verify your account',
-                data: {
-                  preheadertext: 'Verify your account in order to gain access to the wiki.',
-                  title: 'Verify your account',
-                  content: 'Click the button below in order to verify your account and gain access to the wiki.',
-                  buttonLink: `${WIKI.config.host}/verify/${verificationToken}`,
-                  buttonText: 'Verify'
-                },
-                text: `You must open the following link in your browser to verify your account and gain access to the wiki: ${WIKI.config.host}/verify/${verificationToken}`
+              await WIKI.models.users.sendVerificationEmail({
+                email,
+                verificationToken
               })
             } catch (mailErr) {
               WIKI.logger.warn(`Registration verification email could not be delivered: ${mailErr.message}`)
@@ -897,12 +953,17 @@ module.exports = class User extends Model {
    * Logout the current user
    */
   static async logout (context) {
+    const localRedirect = WIKI.config.auth.redirectToLoginAfterLogout ? (WIKI.config.auth.autoLogin ? '/login?all=1' : '/login') : '/'
     if (!context.req.user || context.req.user.id === 2) {
-      return '/'
+      return localRedirect
     }
     const usr = await WIKI.models.users.query().findById(context.req.user.id).select('providerKey')
     const provider = _.find(WIKI.auth.strategies, ['key', usr.providerKey])
-    return provider.logout ? provider.logout(provider.config, context) : '/'
+    const providerRedirect = provider.logout ? provider.logout(provider.config, context) : '/'
+    if (providerRedirect === '/') {
+      return localRedirect
+    }
+    return providerRedirect
   }
 
   static async getGuestUser () {

--- a/server/modules/authentication/keycloak/authentication.js
+++ b/server/modules/authentication/keycloak/authentication.js
@@ -29,6 +29,7 @@ module.exports = {
         try {
           const user = await WIKI.models.users.processProfile({
             providerKey: req.params.strategy,
+            relinkByEmail: true,
             profile: {
               id: profile.keycloakId,
               email: profile.email,

--- a/server/test/models/users.test.js
+++ b/server/test/models/users.test.js
@@ -1,0 +1,142 @@
+const User = require('../../models/users')
+
+describe('models/users account lifecycle', () => {
+  beforeEach(() => {
+    global.WIKI = {
+      auth: {
+        strategies: {}
+      },
+      config: {
+        auth: {
+          autoLogin: false,
+          redirectToLoginAfterLogout: false
+        },
+        host: 'https://wiki.example.com'
+      },
+      data: {
+        authentication: []
+      },
+      logger: {
+        debug: jest.fn(),
+        warn: jest.fn()
+      },
+      mail: {
+        send: jest.fn()
+      },
+      models: {
+        users: {},
+        userKeys: {}
+      }
+    }
+  })
+
+  it('relinks an opted-in provider account by email when its subject changes', async () => {
+    const profilePatch = jest.fn().mockResolvedValue({ id: 42, providerId: 'new-subject' })
+    const relinkedUser = {
+      id: 42,
+      isActive: true,
+      isSystem: false,
+      pictureUrl: '',
+      $query: () => ({ patchAndFetch: profilePatch })
+    }
+    const relinkPatch = jest.fn().mockResolvedValue(relinkedUser)
+    const existingUser = {
+      id: 42,
+      $query: () => ({ patchAndFetch: relinkPatch })
+    }
+    const findOne = jest.fn()
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(existingUser)
+
+    global.WIKI.auth.strategies.keycloak = {
+      key: 'keycloak',
+      strategyKey: 'keycloak',
+      selfRegistration: false
+    }
+    global.WIKI.data.authentication = [{ key: 'keycloak' }]
+    global.WIKI.models.users.query = () => ({ findOne })
+
+    const result = await User.processProfile({
+      providerKey: 'keycloak',
+      relinkByEmail: true,
+      profile: {
+        id: 'new-subject',
+        email: 'User@Example.com',
+        displayName: 'Example User'
+      }
+    })
+
+    expect(findOne).toHaveBeenNthCalledWith(3, {
+      email: 'user@example.com',
+      providerKey: 'keycloak'
+    })
+    expect(relinkPatch).toHaveBeenCalledWith({ providerId: 'new-subject' })
+    expect(profilePatch).toHaveBeenCalledWith(expect.objectContaining({
+      email: 'user@example.com',
+      name: 'Example User'
+    }))
+    expect(result).toEqual({ id: 42, providerId: 'new-subject' })
+  })
+
+  it('replaces verification tokens and sends a generic resend email', async () => {
+    const deleteWhereNot = jest.fn().mockResolvedValue(1)
+    const deleteWhere = jest.fn().mockReturnValue({ whereNot: deleteWhereNot })
+    const sendVerificationEmail = jest.fn().mockResolvedValue()
+    global.WIKI.models.users.query = () => ({
+      where: () => ({
+        first: jest.fn().mockResolvedValue({
+          id: 7,
+          email: 'user@example.com',
+          isActive: true,
+          isVerified: false
+        })
+      })
+    })
+    global.WIKI.models.users.sendVerificationEmail = sendVerificationEmail
+    global.WIKI.models.userKeys = {
+      query: () => ({
+        delete: () => ({ where: deleteWhere })
+      }),
+      generateToken: jest.fn().mockResolvedValue('replacement-token'),
+      destroyToken: jest.fn()
+    }
+
+    await User.loginResendVerification({ email: ' User@Example.com ' })
+
+    expect(global.WIKI.models.userKeys.generateToken).toHaveBeenCalledWith({
+      kind: 'verify',
+      userId: 7
+    })
+    expect(sendVerificationEmail).toHaveBeenCalledWith({
+      email: 'user@example.com',
+      verificationToken: 'replacement-token'
+    })
+    expect(deleteWhere).toHaveBeenCalledWith({ userId: 7, kind: 'verify' })
+    expect(deleteWhereNot).toHaveBeenCalledWith('token', 'replacement-token')
+  })
+
+  it('redirects local logout to the login screen without overriding provider logout', async () => {
+    global.WIKI.config.auth = {
+      autoLogin: true,
+      redirectToLoginAfterLogout: true
+    }
+    global.WIKI.models.users.query = () => ({
+      findById: () => ({
+        select: jest.fn().mockResolvedValue({ providerKey: 'keycloak-instance' })
+      })
+    })
+    global.WIKI.auth.strategies = {
+      local: {
+        key: 'keycloak-instance',
+        config: {},
+        logout: jest.fn().mockReturnValue('/')
+      }
+    }
+
+    await expect(User.logout({ req: { user: { id: 7 } } })).resolves.toBe('/login?all=1')
+
+    global.WIKI.auth.strategies.local.logout.mockReturnValue('https://idp.example.com/logout')
+    await expect(User.logout({ req: { user: { id: 7 } } })).resolves.toBe('https://idp.example.com/logout')
+  })
+})


### PR DESCRIPTION
## Summary

Implements the authentication/account-lifecycle group from `OPEN_V2_ISSUES.md`:

- #1698: allow the Keycloak strategy to relink an existing same-provider account by normalized email when the realm changes its subject identifier
- #1217: add a rate-limited, enumeration-safe resend-verification mutation and login-screen flow; rotate old tokens only after successful delivery
- #1303: add an administrator setting to redirect local logout to the login screen while preserving external provider logout URLs

## Verification

- `yarn jest --runInBand server/test` — 11 suites, 47 tests passed
- `yarn pug-lint server/views`
- ESLint passed on every changed JavaScript and Vue file
- `yarn build` — production client compiled successfully
- `git diff --check`

This PR is independent of #7 and targets the fork’s `main` directly.