### PR TITLE
Complete external authentication group synchronization

### DIFF
--- a/server/db/migrations-sqlite/2.5.315.js
+++ b/server/db/migrations-sqlite/2.5.315.js
@@ -1,0 +1,11 @@
+exports.up = knex => {
+  return knex.schema.alterTable('userGroups', table => {
+    table.string('source').nullable().index()
+  })
+}
+
+exports.down = knex => {
+  return knex.schema.alterTable('userGroups', table => {
+    table.dropColumn('source')
+  })
+}

--- a/server/db/migrations/2.5.315.js
+++ b/server/db/migrations/2.5.315.js
@@ -1,0 +1,11 @@
+exports.up = knex => {
+  return knex.schema.alterTable('userGroups', table => {
+    table.string('source').nullable().index()
+  })
+}
+
+exports.down = knex => {
+  return knex.schema.alterTable('userGroups', table => {
+    table.dropColumn('source')
+  })
+}

--- a/server/helpers/group.js
+++ b/server/helpers/group.js
@@ -1,0 +1,34 @@
+const _ = require('lodash')
+
+module.exports = {
+  normalizeExternalGroupNames (groupNames = []) {
+    const names = _.isArray(groupNames) ? groupNames : [groupNames]
+    return _.uniq(names
+      .filter(_.isString)
+      .map(name => _.trim(name))
+      .filter(name => name.length > 0 && name.length <= 255))
+      .slice(0, 100)
+  },
+
+  getExternalSyncPlan ({ groups, memberships, groupNames, source }) {
+    const normalizedNames = this.normalizeExternalGroupNames(groupNames)
+    const allGroupsByName = _.keyBy(groups, group => group.name.toLowerCase())
+    const availableGroupsByName = _.keyBy(_.reject(groups, 'isSystem'), group => group.name.toLowerCase())
+    const expectedGroupIds = _.uniq(normalizedNames
+      .map(name => {
+        const group = availableGroupsByName[name.toLowerCase()]
+        return group ? group.id : null
+      })
+      .filter(_.isSafeInteger))
+    const currentGroupIds = _.uniq(memberships.map(membership => membership.groupId))
+
+    return {
+      missingGroupNames: normalizedNames.filter(name => !allGroupsByName[name.toLowerCase()]),
+      expectedGroupIds,
+      groupIdsToAdd: _.difference(expectedGroupIds, currentGroupIds),
+      groupIdsToRemove: memberships
+        .filter(membership => membership.source === source && !expectedGroupIds.includes(membership.groupId))
+        .map(membership => membership.groupId)
+    }
+  }
+}

--- a/server/models/groups.js
+++ b/server/models/groups.js
@@ -1,4 +1,7 @@
 const Model = require('objection').Model
+const groupHelper = require('../helpers/group')
+
+/* global WIKI */
 
 /**
  * Groups model
@@ -49,5 +52,62 @@ module.exports = class Group extends Model {
   $beforeInsert() {
     this.createdAt = new Date().toISOString()
     this.updatedAt = new Date().toISOString()
+  }
+
+  /**
+   * Synchronize provider-managed memberships without removing manually
+   * assigned or auto-enrollment groups.
+   */
+  static async syncExternalMemberships ({ user, providerKey, groupNames, createMissingGroups = false }) {
+    const source = `auth:${providerKey}`
+    let groups = await WIKI.models.groups.query()
+    const memberships = await WIKI.models.knex('userGroups')
+      .select('groupId', 'source')
+      .where('userId', user.id)
+    let plan = groupHelper.getExternalSyncPlan({ groups, memberships, groupNames, source })
+    const createdGroups = []
+
+    if (createMissingGroups) {
+      for (const name of plan.missingGroupNames) {
+        const group = await WIKI.models.groups.query().insertAndFetch({
+          name,
+          permissions: JSON.stringify(WIKI.data.groups.defaultPermissions),
+          pageRules: JSON.stringify(WIKI.data.groups.defaultPageRules),
+          isSystem: false
+        })
+        groups.push(group)
+        createdGroups.push(group.id)
+      }
+      plan = groupHelper.getExternalSyncPlan({ groups, memberships, groupNames, source })
+    }
+
+    for (const groupId of plan.groupIdsToAdd) {
+      await WIKI.models.knex('userGroups').insert({
+        userId: user.id,
+        groupId,
+        source
+      })
+    }
+    if (plan.groupIdsToRemove.length > 0) {
+      await WIKI.models.knex('userGroups')
+        .where({ userId: user.id, source })
+        .whereIn('groupId', plan.groupIdsToRemove)
+        .delete()
+    }
+
+    if (createdGroups.length > 0) {
+      await WIKI.auth.reloadGroups()
+      WIKI.events.outbound.emit('reloadGroups')
+    }
+    if (plan.groupIdsToAdd.length > 0 || plan.groupIdsToRemove.length > 0) {
+      WIKI.auth.revokeUserTokens({ id: user.id, kind: 'u' })
+      WIKI.events.outbound.emit('addAuthRevoke', { id: user.id, kind: 'u' })
+    }
+
+    return {
+      createdGroups,
+      addedGroups: plan.groupIdsToAdd,
+      removedGroups: plan.groupIdsToRemove
+    }
   }
 }

--- a/server/modules/authentication/azure/authentication.js
+++ b/server/modules/authentication/azure/authentication.js
@@ -15,12 +15,12 @@ module.exports = {
     // cookieEncryptionKeys is extracted from conf.cookieEncryptionKeyString.
     // It's a concatnation of 44-character length strings each of which represents a single pair of key/iv.
     // Valid cookieEncryptionKeys enables both cookieSameSite and useCookieInsteadOfSession.
-    const keyArray = [];
+    const keyArray = []
     if (conf.cookieEncryptionKeyString) {
-      let keyString = conf.cookieEncryptionKeyString;
+      let keyString = conf.cookieEncryptionKeyString
       while (keyString.length >= 44) {
-        keyArray.push({ key: keyString.substring(0, 32), iv: keyString.substring(32, 44) });
-        keyString = keyString.substring(44);
+        keyArray.push({ key: keyString.substring(0, 32), iv: keyString.substring(32, 44) })
+        keyString = keyString.substring(44)
       }
     }
     passport.use(conf.key,
@@ -50,15 +50,13 @@ module.exports = {
           })
           if (conf.mapGroups) {
             const groups = _.get(profile, '_json.groups')
-            if (groups && _.isArray(groups)) {
-              const currentGroups = (await user.$relatedQuery('groups').select('groups.id')).map(g => g.id)
-              const expectedGroups = Object.values(WIKI.auth.groups).filter(g => groups.includes(g.name)).map(g => g.id)
-              for (const groupId of _.difference(expectedGroups, currentGroups)) {
-                await user.$relatedQuery('groups').relate(groupId)
-              }
-              for (const groupId of _.difference(currentGroups, expectedGroups)) {
-                await user.$relatedQuery('groups').unrelate().where('groupId', groupId)
-              }
+            if (!_.isNil(groups)) {
+              await WIKI.models.groups.syncExternalMemberships({
+                user,
+                providerKey: req.params.strategy,
+                groupNames: groups,
+                createMissingGroups: conf.createMissingGroups
+              })
             }
           }
           cb(null, user)

--- a/server/modules/authentication/azure/definition.yml
+++ b/server/modules/authentication/azure/definition.yml
@@ -33,3 +33,9 @@ props:
     hint: Map groups matching names from the groups claim value
     default: false
     order: 4
+  createMissingGroups:
+    type: Boolean
+    title: Create Missing Groups
+    hint: Create non-system wiki groups when an external group identifier has no existing match.
+    default: false
+    order: 5

--- a/server/modules/authentication/keycloak/authentication.js
+++ b/server/modules/authentication/keycloak/authentication.js
@@ -1,4 +1,5 @@
 const _ = require('lodash')
+const jwt = require('jsonwebtoken')
 
 /* global WIKI */
 
@@ -36,6 +37,18 @@ module.exports = {
               picture: ''
             }
           })
+          if (conf.mapGroups) {
+            const claims = jwt.decode(results.id_token) || {}
+            const groups = _.get(claims, conf.groupsClaim)
+            if (!_.isNil(groups)) {
+              await WIKI.models.groups.syncExternalMemberships({
+                user,
+                providerKey: req.params.strategy,
+                groupNames: groups,
+                createMissingGroups: conf.createMissingGroups
+              })
+            }
+          }
           req.session.keycloak_id_token = results.id_token
           cb(null, user)
         } catch (err) {

--- a/server/modules/authentication/keycloak/definition.yml
+++ b/server/modules/authentication/keycloak/definition.yml
@@ -62,4 +62,22 @@ props:
     title: Legacy Logout Redirect
     hint: Pass the legacy 'redirect_uri' parameter to the logout endpoint. Leave disabled for Keycloak 18 and above.
     order: 10
-
+  mapGroups:
+    type: Boolean
+    title: Map Groups
+    hint: Synchronize provider-managed groups from an ID token claim while preserving manually assigned wiki groups.
+    default: false
+    order: 11
+  groupsClaim:
+    type: String
+    title: Groups Claim
+    hint: ID token claim containing group or role names, for example realm_access.roles.
+    default: realm_access.roles
+    maxWidth: 500
+    order: 12
+  createMissingGroups:
+    type: Boolean
+    title: Create Missing Groups
+    hint: Create non-system wiki groups when a Keycloak role or group has no existing match.
+    default: false
+    order: 13

--- a/server/modules/authentication/ldap/authentication.js
+++ b/server/modules/authentication/ldap/authentication.js
@@ -52,14 +52,12 @@ module.exports = {
             const ldapGroups = _.get(profile, '_groups')
             if (ldapGroups && _.isArray(ldapGroups)) {
               const groups = ldapGroups.map(g => g[conf.groupNameField])
-              const currentGroups = (await user.$relatedQuery('groups').select('groups.id')).map(g => g.id)
-              const expectedGroups = Object.values(WIKI.auth.groups).filter(g => groups.includes(g.name)).map(g => g.id)
-              for (const groupId of _.difference(expectedGroups, currentGroups)) {
-                await user.$relatedQuery('groups').relate(groupId)
-              }
-              for (const groupId of _.difference(currentGroups, expectedGroups)) {
-                await user.$relatedQuery('groups').unrelate().where('groupId', groupId)
-              }
+              await WIKI.models.groups.syncExternalMemberships({
+                user,
+                providerKey: req.params.strategy,
+                groupNames: groups,
+                createMissingGroups: conf.createMissingGroups
+              })
             }
           }
           cb(null, user)

--- a/server/modules/authentication/ldap/definition.yml
+++ b/server/modules/authentication/ldap/definition.yml
@@ -87,36 +87,42 @@ props:
   mapGroups:
     type: Boolean
     title: Map Groups
-    hint: Map groups matching names from the users LDAP/Active Directory groups. Group Search Base must also be defined for this to work. Note this will remove any groups the user has that doesn't match an LDAP/Active Directory group.
+    hint: Synchronize provider-managed groups from LDAP / Active Directory while preserving manually assigned wiki groups. Group Search Base must also be defined for this to work.
     default: false
     order: 24
+  createMissingGroups:
+    type: Boolean
+    title: Create Missing Groups
+    hint: Create non-system wiki groups when an LDAP / Active Directory group name has no existing match.
+    default: false
+    order: 25
   groupSearchBase:
     type: String
     title: Group Search Base
     hint: The base DN from which to search for groups.
     default: OU=groups,dc=example,dc=com
-    order: 25
+    order: 26
   groupSearchFilter:
     type: String
     title: Group Search Filter
     hint: LDAP search filter for groups. (member={{dn}}) will use the distinguished name of the user and will work in most cases.
     default: (member={{dn}})
-    order: 26
+    order: 27
   groupSearchScope:
     type: String
     title: Group Search Scope
     hint: How far from the Group Search Base to search for groups. sub (default) will search the entire subtree. base, will only search the Group Search Base dn. one, will search the Group Search Base dn and one additional level.
     default: sub
-    order: 27
+    order: 28
   groupDnProperty:
     type: String
     title: Group DN Property
     hint: The property of user object to use in {{dn}} interpolation of Group Search Filter.
     default: dn
-    order: 28
+    order: 29
   groupNameField:
     type: String
     title: Group Name Field
     hint: The field that contains the name of the LDAP group to match on, usually "name" or "cn".
     default: name
-    order: 29
+    order: 30

--- a/server/modules/authentication/oauth2/authentication.js
+++ b/server/modules/authentication/oauth2/authentication.js
@@ -35,15 +35,13 @@ module.exports = {
         })
         if (conf.mapGroups) {
           const groups = _.get(profile, conf.groupsClaim)
-          if (groups && _.isArray(groups)) {
-            const currentGroups = (await user.$relatedQuery('groups').select('groups.id')).map(g => g.id)
-            const expectedGroups = Object.values(WIKI.auth.groups).filter(g => groups.includes(g.name)).map(g => g.id)
-            for (const groupId of _.difference(expectedGroups, currentGroups)) {
-              await user.$relatedQuery('groups').relate(groupId)
-            }
-            for (const groupId of _.difference(currentGroups, expectedGroups)) {
-              await user.$relatedQuery('groups').unrelate().where('groupId', groupId)
-            }
+          if (!_.isNil(groups)) {
+            await WIKI.models.groups.syncExternalMemberships({
+              user,
+              providerKey: req.params.strategy,
+              groupNames: groups,
+              createMissingGroups: conf.createMissingGroups
+            })
           }
         }
         cb(null, user)

--- a/server/modules/authentication/oauth2/definition.yml
+++ b/server/modules/authentication/oauth2/definition.yml
@@ -74,25 +74,31 @@ props:
     default: groups
     maxWidth: 500
     order: 11
+  createMissingGroups:
+    type: Boolean
+    title: Create Missing Groups
+    hint: Create non-system wiki groups when an external group name has no existing match.
+    default: false
+    order: 12
   logoutURL:
     type: String
     title: Logout URL
     hint: (optional) Logout URL on the OAuth2 provider where the user will be redirected to complete the logout process.
-    order: 12
+    order: 13
   scope:
     type: String
     title: Scope
     hint: (optional) Application Client permission scopes.
-    order: 13
+    order: 14
   useQueryStringForAccessToken:
     type: Boolean
     default: false
     title: Pass access token via GET query string to User Info Endpoint
     hint: (optional) Pass the access token in an `access_token` parameter attached to the GET query string of the User Info Endpoint URL. Otherwise the access token will be passed in the Authorization header.
-    order: 14
+    order: 15
   enableCSRFProtection:
     type: Boolean
     default: true
     title: Enable CSRF protection
     hint: Pass a nonce state parameter during authentication to protect against CSRF attacks.
-    order: 15
+    order: 16

--- a/server/modules/authentication/oidc/authentication.js
+++ b/server/modules/authentication/oidc/authentication.js
@@ -38,15 +38,13 @@ module.exports = {
           })
           if (conf.mapGroups) {
             const groups = _.get(profile, '_json.' + conf.groupsClaim)
-            if (groups && _.isArray(groups)) {
-              const currentGroups = (await user.$relatedQuery('groups').select('groups.id')).map(g => g.id)
-              const expectedGroups = Object.values(WIKI.auth.groups).filter(g => groups.includes(g.name)).map(g => g.id)
-              for (const groupId of _.difference(expectedGroups, currentGroups)) {
-                await user.$relatedQuery('groups').relate(groupId)
-              }
-              for (const groupId of _.difference(currentGroups, expectedGroups)) {
-                await user.$relatedQuery('groups').unrelate().where('groupId', groupId)
-              }
+            if (!_.isNil(groups)) {
+              await WIKI.models.groups.syncExternalMemberships({
+                user,
+                providerKey: req.params.strategy,
+                groupNames: groups,
+                createMissingGroups: conf.createMissingGroups
+              })
             }
           }
           cb(null, user)

--- a/server/modules/authentication/oidc/definition.yml
+++ b/server/modules/authentication/oidc/definition.yml
@@ -82,13 +82,19 @@ props:
     default: groups
     maxWidth: 500
     order: 12
+  createMissingGroups:
+    type: Boolean
+    title: Create Missing Groups
+    hint: Create non-system wiki groups when an external group name has no existing match.
+    default: false
+    order: 13
   logoutURL:
     type: String
     title: Logout URL
     hint: (optional) Logout URL on the OAuth2 provider where the user will be redirected to complete the logout process.
-    order: 13
+    order: 14
   acrValues:
     type: String
     title: ACR Values
     hint: (optional) Authentication Context Class Reference
-    order: 14
+    order: 15

--- a/server/modules/authentication/saml/authentication.js
+++ b/server/modules/authentication/saml/authentication.js
@@ -64,15 +64,13 @@ module.exports = {
             const maybeArrayOfGroups = _.get(profile.attributes, conf.mappingGroups)
             const groups = (maybeArrayOfGroups && !_.isArray(maybeArrayOfGroups)) ? [maybeArrayOfGroups] : maybeArrayOfGroups
 
-            if (groups && _.isArray(groups)) {
-              const currentGroups = (await user.$relatedQuery('groups').select('groups.id')).map(g => g.id)
-              const expectedGroups = Object.values(WIKI.auth.groups).filter(g => groups.includes(g.name)).map(g => g.id)
-              for (const groupId of _.difference(expectedGroups, currentGroups)) {
-                await user.$relatedQuery('groups').relate(groupId)
-              }
-              for (const groupId of _.difference(currentGroups, expectedGroups)) {
-                await user.$relatedQuery('groups').unrelate().where('groupId', groupId)
-              }
+            if (!_.isNil(groups)) {
+              await WIKI.models.groups.syncExternalMemberships({
+                user,
+                providerKey: req.params.strategy,
+                groupNames: groups,
+                createMissingGroups: conf.createMissingGroups
+              })
             }
           }
 

--- a/server/modules/authentication/saml/definition.yml
+++ b/server/modules/authentication/saml/definition.yml
@@ -165,7 +165,7 @@ props:
   mapGroups:
     type: Boolean
     title: Map Groups
-    hint: Map groups matching names from the provider user groups. User Groups Field Mapping must also be defined for this to work. Note this will remove any groups the user has that doesn't match any group from the provider.
+    hint: Synchronize provider-managed groups while preserving manually assigned wiki groups. User Groups Field Mapping must also be defined for this to work.
     default: false
     order: 44
   mappingGroups:
@@ -174,3 +174,9 @@ props:
     default: 'memberOf'
     hint: The field storing the user groups attribute (when Map Groups is enabled). Can be a variable name or a URI-formatted string.
     order: 45
+  createMissingGroups:
+    type: Boolean
+    title: Create Missing Groups
+    hint: Create non-system wiki groups when a provider group name has no existing match.
+    default: false
+    order: 46

--- a/server/test/helpers/group.test.js
+++ b/server/test/helpers/group.test.js
@@ -1,0 +1,44 @@
+const groupHelper = require('../../helpers/group')
+
+describe('helpers/group external synchronization', () => {
+  const groups = [
+    { id: 1, name: 'Administrators', isSystem: true },
+    { id: 3, name: 'Editors', isSystem: false },
+    { id: 4, name: 'Reviewers', isSystem: false }
+  ]
+
+  it('normalizes external names and ignores invalid values', () => {
+    expect(groupHelper.normalizeExternalGroupNames([' Editors ', '', null, 'Editors'])).toEqual(['Editors'])
+  })
+
+  it('preserves manual memberships and removes only stale memberships from the same provider', () => {
+    expect(groupHelper.getExternalSyncPlan({
+      groups,
+      memberships: [
+        { groupId: 3, source: null },
+        { groupId: 4, source: 'auth:oidc-main' },
+        { groupId: 7, source: 'auth:other' }
+      ],
+      groupNames: ['Editors'],
+      source: 'auth:oidc-main'
+    })).toMatchObject({
+      expectedGroupIds: [3],
+      groupIdsToAdd: [],
+      groupIdsToRemove: [4]
+    })
+  })
+
+  it('never maps or recreates system groups and reports genuinely missing groups', () => {
+    expect(groupHelper.getExternalSyncPlan({
+      groups,
+      memberships: [],
+      groupNames: ['Administrators', 'Authors'],
+      source: 'auth:oidc-main'
+    })).toEqual({
+      missingGroupNames: ['Authors'],
+      expectedGroupIds: [],
+      groupIdsToAdd: [],
+      groupIdsToRemove: []
+    })
+  })
+})

--- a/server/test/models/groups.test.js
+++ b/server/test/models/groups.test.js
@@ -1,0 +1,111 @@
+const knexFactory = require('knex')
+const Group = require('../../models/groups')
+const migration = require('../../db/migrations-sqlite/2.5.315')
+
+describe('models/groups external membership synchronization', () => {
+  let db
+
+  beforeEach(async () => {
+    db = knexFactory({
+      client: 'sqlite3',
+      connection: { filename: ':memory:' },
+      useNullAsDefault: true
+    })
+    await db.schema.createTable('userGroups', table => {
+      table.increments('id').primary()
+      table.integer('userId').notNullable()
+      table.integer('groupId').notNullable()
+    })
+    await migration.up(db)
+
+    global.WIKI = {
+      auth: {
+        reloadGroups: jest.fn(),
+        revokeUserTokens: jest.fn()
+      },
+      data: {
+        groups: {
+          defaultPermissions: ['read:pages'],
+          defaultPageRules: []
+        }
+      },
+      events: {
+        outbound: {
+          emit: jest.fn()
+        }
+      },
+      models: {
+        groups: {},
+        knex: db
+      }
+    }
+  })
+
+  afterEach(async () => {
+    await db.destroy()
+  })
+
+  it('adds and rolls back provider source tracking', async () => {
+    await expect(db('userGroups').columnInfo('source')).resolves.toMatchObject({ type: 'varchar' })
+    await migration.down(db)
+    await expect(db('userGroups').columnInfo()).resolves.not.toHaveProperty('source')
+  })
+
+  it('adds and removes only memberships managed by the active provider', async () => {
+    await db('userGroups').insert([
+      { userId: 9, groupId: 3, source: null },
+      { userId: 9, groupId: 5, source: 'auth:oidc-main' },
+      { userId: 9, groupId: 7, source: 'auth:other' }
+    ])
+    global.WIKI.models.groups.query = jest.fn().mockResolvedValue([
+      { id: 1, name: 'Administrators', isSystem: true },
+      { id: 3, name: 'Editors', isSystem: false },
+      { id: 4, name: 'Reviewers', isSystem: false }
+    ])
+
+    const result = await Group.syncExternalMemberships({
+      user: { id: 9 },
+      providerKey: 'oidc-main',
+      groupNames: ['Administrators', 'Editors', 'Reviewers']
+    })
+
+    expect(result).toEqual({
+      createdGroups: [],
+      addedGroups: [4],
+      removedGroups: [5]
+    })
+    await expect(db('userGroups').select('groupId', 'source').where('userId', 9).orderBy('groupId')).resolves.toEqual([
+      { groupId: 3, source: null },
+      { groupId: 4, source: 'auth:oidc-main' },
+      { groupId: 7, source: 'auth:other' }
+    ])
+    expect(global.WIKI.auth.revokeUserTokens).toHaveBeenCalledWith({ id: 9, kind: 'u' })
+  })
+
+  it('can create missing non-system groups with safe default permissions', async () => {
+    const groups = [{ id: 1, name: 'Administrators', isSystem: true }]
+    const insertAndFetch = jest.fn().mockResolvedValue({ id: 8, name: 'Authors', isSystem: false })
+    global.WIKI.models.groups.query = jest.fn()
+      .mockResolvedValueOnce(groups)
+      .mockReturnValueOnce({ insertAndFetch })
+
+    const result = await Group.syncExternalMemberships({
+      user: { id: 9 },
+      providerKey: 'ldap-main',
+      groupNames: ['Administrators', 'Authors'],
+      createMissingGroups: true
+    })
+
+    expect(insertAndFetch).toHaveBeenCalledWith({
+      name: 'Authors',
+      permissions: JSON.stringify(['read:pages']),
+      pageRules: JSON.stringify([]),
+      isSystem: false
+    })
+    expect(result.createdGroups).toEqual([8])
+    expect(await db('userGroups').where({ userId: 9, groupId: 8 }).first()).toMatchObject({
+      source: 'auth:ldap-main'
+    })
+    expect(global.WIKI.auth.reloadGroups).toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary

Implements #1874 from `OPEN_V2_ISSUES.md`:

- centralize group synchronization for OIDC, OAuth2, LDAP, SAML, Azure AD, and Keycloak
- track provider-owned memberships with a portable `userGroups.source` migration
- preserve manual and auto-enrolled memberships
- remove only stale memberships owned by the same authentication strategy
- block external claims from mapping to or recreating system groups
- optionally create missing non-system groups with safe default permissions
- support configurable Keycloak ID-token role/group claims
- revoke existing user tokens after membership changes

## Verification

- `yarn jest --runInBand server/test` — 12 suites, 50 tests passed
- SQLite migration up/down covered by tests
- all six authentication definition YAML files parsed successfully
- `yarn pug-lint server/views`
- ESLint passed on every changed JavaScript file
- `git diff --check`

This PR is independent of #7 and #8 and targets the fork’s `main` directly.